### PR TITLE
Prepare examples for RCP release 24.2.1

### DIFF
--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -30,7 +30,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />

--- a/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
+++ b/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
@@ -75,15 +75,15 @@
     </language>
     <language id="2283d35c-b541-4c39-bf04-8310ba3f92ff" name="com.moraad.reports">
       <concept id="5662992976716575613" name="com.moraad.reports.structure.ThreatScenariosAndAttackPathsReportItem" flags="ng" index="28bWPA">
-        <property id="5844418852561495228" name="limit" index="1CBqX7" />
+        <property id="5844418852561495228" name="attackPathLimit" index="1CBqX7" />
       </concept>
       <concept id="2050517468709281410" name="com.moraad.reports.structure.AssetsAndDamageScenariosTableReportItem" flags="ng" index="ckFx4" />
-      <concept id="6986877318773201239" name="com.moraad.reports.structure.ComponentDiagramReportItem" flags="ng" index="ygSqK">
+      <concept id="6986877318773201239" name="com.moraad.reports.structure.SystemDiagramReportItem" flags="ng" index="ygSqK">
         <reference id="1019912726748740255" name="diagram" index="2HTkYB" />
       </concept>
       <concept id="6986877318773203685" name="com.moraad.reports.structure.RiskTableReportItem" flags="ng" index="ygVO2" />
-      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlsTableReportItem" flags="ng" index="ygVO4" />
-      <concept id="6986877318773203681" name="com.moraad.reports.structure.ThreatTableReportItem" flags="ng" index="ygVO6" />
+      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlTableReportItem" flags="ng" index="ygVO4" />
+      <concept id="6986877318773203681" name="com.moraad.reports.structure.AttackStepTableReportItem" flags="ng" index="ygVO6" />
       <concept id="6986877318773203653" name="com.moraad.reports.structure.AssumptionTableReportItem" flags="ng" index="ygVOy" />
       <concept id="6986877318772884603" name="com.moraad.reports.structure.RiskDistributionChartReportItem" flags="ng" index="yhPIs" />
       <concept id="6986877318772702512" name="com.moraad.reports.structure.ProjectInfoReportItem" flags="ng" index="ym6bn">

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -29,7 +29,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -26,7 +26,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -29,7 +29,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -99,33 +99,31 @@
       </concept>
       <concept id="9037100677461558833" name="com.moraad.reports.structure.GoalTableReportItem" flags="ng" index="2SZOu" />
       <concept id="5662992976716575613" name="com.moraad.reports.structure.ThreatScenariosAndAttackPathsReportItem" flags="ng" index="28bWPA">
-        <property id="5844418852561495228" name="limit" index="1CBqX7" />
-        <property id="5784576005910096338" name="limitNumberOfAttackPathPerThreatScenario" index="3CKxzC" />
+        <property id="5844418852561495228" name="attackPathLimit" index="1CBqX7" />
+        <property id="5784576005910096338" name="limitNumberOfAttackPathsPerThreatScenario" index="3CKxzC" />
       </concept>
-      <concept id="7385129922939695098" name="com.moraad.reports.structure.AttackEffortsMatrixReportItem" flags="ng" index="a$eXN" />
+      <concept id="7385129922939695098" name="com.moraad.reports.structure.AttackFeasibilityMatrixReportItem" flags="ng" index="a$eXN" />
       <concept id="7385129922949653722" name="com.moraad.reports.structure.RiskLevelMatrixReportItem" flags="ng" index="bYehj" />
       <concept id="2050517468709281410" name="com.moraad.reports.structure.AssetsAndDamageScenariosTableReportItem" flags="ng" index="ckFx4">
         <property id="8417410718506888096" name="showNonAssets" index="9YSRj" />
       </concept>
-      <concept id="288157383581295240" name="com.moraad.reports.structure.DamagePotentialsTableReportItem" flags="ng" index="kePWl" />
-      <concept id="288157383577698444" name="com.moraad.reports.structure.SecurityGoalClassesTableReportItem" flags="ng" index="ksrOh" />
+      <concept id="288157383581295240" name="com.moraad.reports.structure.ImpactLevelsTableReportItem" flags="ng" index="kePWl" />
+      <concept id="288157383577698444" name="com.moraad.reports.structure.SecurityPropertiesTableReportItem" flags="ng" index="ksrOh" />
+      <concept id="2889406642063639953" name="com.moraad.reports.structure.IHaveRationale" flags="ng" index="nKFAp">
+        <property id="2889406642063639954" name="exportRationale" index="nKFAq" />
+        <property id="2889406642063639956" name="exportRationaleKeyword" index="nKFAs" />
+      </concept>
       <concept id="288157383598696227" name="com.moraad.reports.structure.RiskLevelsTableReportItem" flags="ng" index="rctEY" />
-      <concept id="288157383594267526" name="com.moraad.reports.structure.AttackEffortLevelsTableReportItem" flags="ng" index="rtmSr" />
+      <concept id="288157383594267526" name="com.moraad.reports.structure.AttackFeasibilityLevelsTableReportItem" flags="ng" index="rtmSr" />
       <concept id="6986877318773217091" name="com.moraad.reports.structure.TextReportItem" flags="ng" index="yg4y$">
         <property id="6986877318773333397" name="text" index="ygo9M" />
       </concept>
-      <concept id="6986877318773201239" name="com.moraad.reports.structure.ComponentDiagramReportItem" flags="ng" index="ygSqK">
+      <concept id="6986877318773201239" name="com.moraad.reports.structure.SystemDiagramReportItem" flags="ng" index="ygSqK">
         <reference id="1019912726748740255" name="diagram" index="2HTkYB" />
       </concept>
       <concept id="6986877318773203685" name="com.moraad.reports.structure.RiskTableReportItem" flags="ng" index="ygVO2" />
-      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlsTableReportItem" flags="ng" index="ygVO4">
-        <property id="3868026684445433283" name="showRationaleKeyword" index="2DHY05" />
-        <property id="3868026684445433281" name="exportRationale" index="2DHY07" />
-      </concept>
-      <concept id="6986877318773203681" name="com.moraad.reports.structure.ThreatTableReportItem" flags="ng" index="ygVO6">
-        <property id="2115212867104374631" name="exportRationale" index="1djs62" />
-        <property id="2115212867105558218" name="showRationaleKeyword" index="1dsN0J" />
-      </concept>
+      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlTableReportItem" flags="ng" index="ygVO4" />
+      <concept id="6986877318773203681" name="com.moraad.reports.structure.AttackStepTableReportItem" flags="ng" index="ygVO6" />
       <concept id="6986877318773203653" name="com.moraad.reports.structure.AssumptionTableReportItem" flags="ng" index="ygVOy" />
       <concept id="6986877318772884603" name="com.moraad.reports.structure.RiskDistributionChartReportItem" flags="ng" index="yhPIs" />
       <concept id="6986877318772702512" name="com.moraad.reports.structure.ProjectInfoReportItem" flags="ng" index="ym6bn">
@@ -137,23 +135,19 @@
       <concept id="6986877318770896277" name="com.moraad.reports.structure.ResultReportChunk" flags="ng" index="ypf9M">
         <child id="6986877318770902011" name="items" index="yp9Ks" />
       </concept>
-      <concept id="9125927369354634356" name="com.moraad.reports.structure.RiskFactorsTableReportItem" flags="ng" index="AK2Fz" />
-      <concept id="9125927369345168869" name="com.moraad.reports.structure.DamageClassesTableReportItem" flags="ng" index="DsbHM" />
+      <concept id="9125927369354634356" name="com.moraad.reports.structure.FeasibilityCategoriesTableReportItem" flags="ng" index="AK2Fz" />
+      <concept id="9125927369345168869" name="com.moraad.reports.structure.ImpactCategoriesTableReportItem" flags="ng" index="DsbHM" />
       <concept id="1488669593885577694" name="com.moraad.reports.structure.CommentReportItem" flags="ng" index="2JOk35">
         <property id="1488669593885577696" name="text" index="2JOk3V" />
       </concept>
       <concept id="981657859280632006" name="com.moraad.reports.structure.DamageScenarioTablePerStakeholderReportItem" flags="ng" index="OYZhp">
         <property id="981657859280632007" name="impactOptionByName" index="OYZho" />
-        <property id="3537459689840296141" name="includeHiddenIO" index="1d9_gl" />
+        <property id="3537459689840296141" name="includeHiddenImpactOptions" index="1d9_gl" />
       </concept>
       <concept id="5476579115479223259" name="com.moraad.reports.structure.RequirementTableReportItem" flags="ng" index="QtJLF" />
       <concept id="5209880561343667327" name="com.moraad.reports.structure.PIContentItem" flags="ng" index="XlMEV">
         <property id="5209880561343667337" name="export" index="XlMDd" />
         <reference id="5209880561343674428" name="target" index="XlKVS" />
-      </concept>
-      <concept id="6495719316991181964" name="com.moraad.reports.structure.ConceptElementTableReportItem" flags="ng" index="3bKAF1">
-        <property id="8214906305372118731" name="showRationaleKeyWord" index="3gOQG9" />
-        <property id="8214906305339968148" name="exportRationale" index="3iTJXm" />
       </concept>
       <concept id="2137954257241981602" name="com.moraad.reports.structure.CsConceptTableReportItem" flags="ng" index="3dmGyN">
         <property id="1525157778248090205" name="listImmediateElements" index="VNb2Q" />
@@ -171,8 +165,6 @@
       <concept id="8588388912954219383" name="com.moraad.reports.structure.DamageScenarioTableReportItem" flags="ng" index="3UIwP1">
         <property id="3063787601294055561" name="excludeImpactScale" index="gT1Cu" />
         <property id="4807182361674910968" name="exportNBOS" index="GBCor" />
-        <property id="8588388912954702330" name="exportRationale" index="3UCmZc" />
-        <property id="8588388912954702331" name="showRationaleKeyWord" index="3UCmZd" />
       </concept>
       <concept id="9037100677490252154" name="com.moraad.reports.structure.ClaimTableReportItem" flags="ng" index="3Wlq9l" />
     </language>
@@ -3649,11 +3641,11 @@
     <node concept="ymko6" id="1k$QKsQS5_$" role="yp9Ks" />
     <node concept="ygVO6" id="1k$QKsQS6_a" role="yp9Ks" />
     <node concept="ygVO6" id="1k$QKsQS7zX" role="yp9Ks">
-      <property role="1djs62" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="ygVO6" id="1VvRu3aCB56" role="yp9Ks">
-      <property role="1djs62" value="true" />
-      <property role="1dsN0J" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="ymko6" id="1k$QKsQS8zI" role="yp9Ks" />
     <node concept="3xttxO" id="1k$QKsQS93e" role="yp9Ks" />
@@ -3662,11 +3654,11 @@
     <node concept="ymko6" id="1VvRu3aCB6p" role="yp9Ks" />
     <node concept="3Wlq9l" id="1VvRu3aCBd4" role="yp9Ks" />
     <node concept="3Wlq9l" id="1YUD_SAIGfm" role="yp9Ks">
-      <property role="3iTJXm" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="3Wlq9l" id="1YUD_SAIGgR" role="yp9Ks">
-      <property role="3iTJXm" value="true" />
-      <property role="3gOQG9" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="ymko6" id="1VvRu3aCBan" role="yp9Ks" />
     <node concept="2JOk35" id="1k$QKsQSa4$" role="yp9Ks">
@@ -3682,59 +3674,59 @@
     <node concept="ymko6" id="1VvRu3aCBfN" role="yp9Ks" />
     <node concept="ygVO4" id="1k$QKsQSc7y" role="yp9Ks" />
     <node concept="ygVO4" id="1k$QKsQScB0" role="yp9Ks">
-      <property role="2DHY07" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="ygVO4" id="1k$QKsQSd7$" role="yp9Ks">
-      <property role="2DHY07" value="true" />
-      <property role="2DHY05" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="ymko6" id="1k$QKsQSiXe" role="yp9Ks" />
     <node concept="3UIwP1" id="1k$QKsQSjuh" role="yp9Ks" />
     <node concept="3UIwP1" id="1k$QKsQSjXO" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="3UIwP1" id="1k$QKsQSku_" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
-      <property role="3UCmZd" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="3UIwP1" id="1VvRu3aCBiB" role="yp9Ks">
       <property role="gT1Cu" value="true" />
     </node>
     <node concept="3UIwP1" id="1VvRu3aCBiA" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
       <property role="gT1Cu" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="3UIwP1" id="1VvRu3aCBi_" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
-      <property role="3UCmZd" value="true" />
       <property role="gT1Cu" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="3UIwP1" id="6d2LuSswIUp" role="yp9Ks">
       <property role="GBCor" value="true" />
     </node>
     <node concept="3UIwP1" id="6d2LuSswIUo" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
       <property role="GBCor" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="3UIwP1" id="6d2LuSswIUn" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
-      <property role="3UCmZd" value="true" />
       <property role="GBCor" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="3UIwP1" id="6d2LuSswIUm" role="yp9Ks">
       <property role="gT1Cu" value="true" />
       <property role="GBCor" value="true" />
     </node>
     <node concept="3UIwP1" id="6d2LuSswIUl" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
       <property role="gT1Cu" value="true" />
       <property role="GBCor" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="3UIwP1" id="6d2LuSswIUk" role="yp9Ks">
-      <property role="3UCmZc" value="true" />
-      <property role="3UCmZd" value="true" />
       <property role="gT1Cu" value="true" />
       <property role="GBCor" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="ymko6" id="1k$QKsQSkYa" role="yp9Ks" />
     <node concept="OYZhp" id="1VvRu3aCBmY" role="yp9Ks">
@@ -3765,11 +3757,11 @@
     <node concept="ymko6" id="1k$QKsQSsvK" role="yp9Ks" />
     <node concept="2SZOu" id="1VvRu3aCBw1" role="yp9Ks" />
     <node concept="2SZOu" id="1YUD_SAIGip" role="yp9Ks">
-      <property role="3iTJXm" value="true" />
+      <property role="nKFAq" value="true" />
     </node>
     <node concept="2SZOu" id="1YUD_SAIGjW" role="yp9Ks">
-      <property role="3iTJXm" value="true" />
-      <property role="3gOQG9" value="true" />
+      <property role="nKFAq" value="true" />
+      <property role="nKFAs" value="true" />
     </node>
     <node concept="ymko6" id="1VvRu3aCBuu" role="yp9Ks" />
     <node concept="DsbHM" id="1k$QKsQSt1x" role="yp9Ks" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -29,7 +29,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -98,12 +98,12 @@
       <concept id="6986877318773217091" name="com.moraad.reports.structure.TextReportItem" flags="ng" index="yg4y$">
         <property id="6986877318773333397" name="text" index="ygo9M" />
       </concept>
-      <concept id="6986877318773201239" name="com.moraad.reports.structure.ComponentDiagramReportItem" flags="ng" index="ygSqK">
+      <concept id="6986877318773201239" name="com.moraad.reports.structure.SystemDiagramReportItem" flags="ng" index="ygSqK">
         <reference id="1019912726748740255" name="diagram" index="2HTkYB" />
       </concept>
       <concept id="6986877318773203685" name="com.moraad.reports.structure.RiskTableReportItem" flags="ng" index="ygVO2" />
-      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlsTableReportItem" flags="ng" index="ygVO4" />
-      <concept id="6986877318773203681" name="com.moraad.reports.structure.ThreatTableReportItem" flags="ng" index="ygVO6" />
+      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlTableReportItem" flags="ng" index="ygVO4" />
+      <concept id="6986877318773203681" name="com.moraad.reports.structure.AttackStepTableReportItem" flags="ng" index="ygVO6" />
       <concept id="6986877318773203653" name="com.moraad.reports.structure.AssumptionTableReportItem" flags="ng" index="ygVOy" />
       <concept id="6986877318772884603" name="com.moraad.reports.structure.RiskDistributionChartReportItem" flags="ng" index="yhPIs">
         <property id="6552748594463309586" name="showPreview" index="2DBfkM" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -26,7 +26,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -29,7 +29,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -96,12 +96,12 @@
       <concept id="6986877318773217091" name="com.moraad.reports.structure.TextReportItem" flags="ng" index="yg4y$">
         <property id="6986877318773333397" name="text" index="ygo9M" />
       </concept>
-      <concept id="6986877318773201239" name="com.moraad.reports.structure.ComponentDiagramReportItem" flags="ng" index="ygSqK">
+      <concept id="6986877318773201239" name="com.moraad.reports.structure.SystemDiagramReportItem" flags="ng" index="ygSqK">
         <reference id="1019912726748740255" name="diagram" index="2HTkYB" />
       </concept>
       <concept id="6986877318773203685" name="com.moraad.reports.structure.RiskTableReportItem" flags="ng" index="ygVO2" />
-      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlsTableReportItem" flags="ng" index="ygVO4" />
-      <concept id="6986877318773203681" name="com.moraad.reports.structure.ThreatTableReportItem" flags="ng" index="ygVO6" />
+      <concept id="6986877318773203683" name="com.moraad.reports.structure.ControlTableReportItem" flags="ng" index="ygVO4" />
+      <concept id="6986877318773203681" name="com.moraad.reports.structure.AttackStepTableReportItem" flags="ng" index="ygVO6" />
       <concept id="6986877318773203653" name="com.moraad.reports.structure.AssumptionTableReportItem" flags="ng" index="ygVOy" />
       <concept id="6986877318772884603" name="com.moraad.reports.structure.RiskDistributionChartReportItem" flags="ng" index="yhPIs">
         <property id="6552748594463309586" name="showPreview" index="2DBfkM" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -29,7 +29,7 @@
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
-    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />
+    <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
     <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />


### PR DESCRIPTION
this PR migrates the examples to enable report template serialization in the 24.2.1 patch release and forward