### PR TITLE
Prepare examples for RCP release 24.3

### DIFF
--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -63,8 +63,16 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="1f27859a-c6f3-4ef1-b3b2-a3b47ab45240(CvssAvAnalysis)" version="0" />
     <module reference="440b241b-03fb-49dd-83b9-a5c49e6386e5(CvssAvComposition)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -74,6 +82,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -27,7 +27,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
+++ b/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
@@ -1351,7 +1351,7 @@
         <node concept="3VMn$a" id="5F0rLLZnjYq" role="3GS99T" />
       </node>
       <node concept="3GSqTS" id="1PEmpgFm8fd" role="2H0S5D">
-        <property role="TrG5h" value="18" />
+        <property role="TrG5h" value="18 Devices connected to external interfaces e.g. USB ports, OBD port, used as a means to attack vehicle systems" />
       </node>
       <node concept="2H0S4X" id="1PEmpgFm8fe" role="2H0S5D">
         <property role="TrG5h" value="External interfaces such as USB or other ports used as a point of attack, for example through code injection" />

--- a/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
+++ b/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
@@ -1034,42 +1034,54 @@
         <property role="133MFP" value="" />
         <node concept="2Q16Lc" id="501$dK$Svza" role="3aHmvd">
           <ref role="2ClQv0" node="1c2jTNFeWJh" resolve="TS.1" />
-          <node concept="CLQ85" id="501$dK$Svzb" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKEyQJ" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1c2jTNFeWJh" resolve="TS.1" />
             <ref role="2Dj$GC" node="1c2jTNFeWJh" resolve="TS.1" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$Svzc" role="3aHmvd">
           <ref role="2ClQv0" node="1c2jTNFhKVX" resolve="TS.2" />
-          <node concept="CLQ85" id="501$dK$Svzd" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKEyQX" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1c2jTNFhKVX" resolve="TS.2" />
             <ref role="2Dj$GC" node="1c2jTNFhKVX" resolve="TS.2" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$Svze" role="3aHmvd">
           <ref role="2ClQv0" node="1c2jTNFhKXi" resolve="TS.3" />
-          <node concept="CLQ85" id="501$dK$Svzf" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKEyRb" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1c2jTNFhKXi" resolve="TS.3" />
             <ref role="2Dj$GC" node="1c2jTNFhKXi" resolve="TS.3" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$Svzg" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTKEB" resolve="TS.4" />
-          <node concept="CLQ85" id="501$dK$Svzh" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKEyRp" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTKEB" resolve="TS.4" />
             <ref role="2Dj$GC" node="60wEthBTKEB" resolve="TS.4" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$Svzi" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTKEM" resolve="TS.5" />
-          <node concept="CLQ85" id="501$dK$Svzj" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKEyRB" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTKEM" resolve="TS.5" />
             <ref role="2Dj$GC" node="60wEthBTKEM" resolve="TS.5" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$Svzk" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTKEU" resolve="TS.6" />
-          <node concept="CLQ85" id="501$dK$Svzl" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKEyRP" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTKEU" resolve="TS.6" />
             <ref role="2Dj$GC" node="60wEthBTKEU" resolve="TS.6" />
           </node>

--- a/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
+++ b/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
@@ -266,7 +266,10 @@
         <child id="3260991312725608311" name="newDataFlowsChunk" index="1BT5$_" />
         <child id="7472593337833908268" name="rootComponent" index="3Vepgw" />
       </concept>
-      <concept id="5188113475688114801" name="com.moraad.components.structure.FunctionAssignmentChunk" flags="ng" index="2zckJ6" />
+      <concept id="5188113475688114801" name="com.moraad.components.structure.FunctionAssignmentChunk" flags="ng" index="2zckJ6">
+        <property id="8675533035648326051" name="showSmartViewByDefault" index="32ArrR" />
+        <child id="2903910728803980" name="functionAssignables" index="1Bunur" />
+      </concept>
       <concept id="4250072277178649485" name="com.moraad.components.structure.TOEChunkRef" flags="ng" index="3$0O6U">
         <reference id="4250072277178649488" name="target" index="3$0O6B" />
       </concept>
@@ -1124,6 +1127,19 @@
   </node>
   <node concept="2zckJ6" id="1PEmpgFm7ws">
     <property role="3GE5qa" value="Item Definition" />
+    <property role="32ArrR" value="true" />
+    <node concept="3$0O7b" id="1V484Ri7I87" role="1Bunur">
+      <ref role="122Z_O" node="1c2jTNFeWJa" resolve="Cmp.1" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I88" role="1Bunur">
+      <ref role="122Z_O" node="1c2jTNFhLbE" resolve="Cmp.2" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I89" role="1Bunur">
+      <ref role="122Z_O" node="1c2jTNFhLbK" resolve="Cmp.3" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I86" role="1Bunur">
+      <ref role="122Z_O" node="5a5CPNXLFO9" resolve="SYS" />
+    </node>
   </node>
   <node concept="2H3I8p" id="1PEmpgFm8e1">
     <property role="TrG5h" value="UN R155 Threats" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -62,7 +62,15 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="440b241b-03fb-49dd-83b9-a5c49e6386e5(CvssAvComposition)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -72,6 +80,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/CvssAv/CvssAvComposition/models/MethodConfiguration.mps
+++ b/CvssAv/CvssAvComposition/models/MethodConfiguration.mps
@@ -11,6 +11,9 @@
   </imports>
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
+      <concept id="8140327204155191530" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelsDefinition" flags="ng" index="fTz2s">
+        <child id="8140327204155191533" name="levels" index="fTz2r" />
+      </concept>
       <concept id="4497791247486336887" name="de.itemis.ysec.methodConfiguration.structure.DamageClass" flags="ng" index="i8Y8S" />
       <concept id="7480212422238926806" name="de.itemis.ysec.methodConfiguration.structure.ImpactScale" flags="ng" index="2nNfD6">
         <property id="7480212422238960135" name="value" index="2nMRun" />
@@ -28,6 +31,19 @@
         <property id="8045787582102992758" name="value" index="uPLpr" />
       </concept>
       <concept id="5265403561757222969" name="de.itemis.ysec.methodConfiguration.structure.Stakeholder" flags="ng" index="CzX2t" />
+      <concept id="848894267652668100" name="de.itemis.ysec.methodConfiguration.structure.TrustLevel" flags="ng" index="2KyDCi">
+        <property id="7152850790341018718" name="value" index="qSweV" />
+      </concept>
+      <concept id="848894267651765571" name="de.itemis.ysec.methodConfiguration.structure.TrustModel" flags="ng" index="2KY5ml">
+        <child id="8140327204155204736" name="trustLevelsDefinition" index="fTIjQ" />
+        <child id="4520112907071583232" name="trustBoundaryCategoriesDefinition" index="2O4_UX" />
+      </concept>
+      <concept id="4520112907071582378" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategoriesDefinition" flags="ng" index="2O4_Cn">
+        <child id="4520112907071582379" name="categories" index="2O4_Cm" />
+      </concept>
+      <concept id="4520112907071235583" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategory" flags="ng" index="2O6gX2">
+        <property id="4520112907071235800" name="value" index="2O6gL_" />
+      </concept>
       <concept id="1756525789544303273" name="de.itemis.ysec.methodConfiguration.structure.DamagePotentialsDefinition" flags="ng" index="OYqhf">
         <child id="1756525789544303274" name="values" index="OYqhc" />
       </concept>
@@ -3720,6 +3736,176 @@
   <node concept="3XX4$o" id="65pzHM4F7aL">
     <property role="TrG5h" value="ISO/SAE 21434 Terminology" />
     <ref role="3iLw6d" to="si5v:3xoDER5IZYq" resolve="ISO/SAE 21434 Terminology (Default)" />
+  </node>
+  <node concept="2KY5ml" id="2kMEKexN5T">
+    <property role="TrG5h" value="Trust Model" />
+    <node concept="fTz2s" id="73Sg7pZ8d6f" role="fTIjQ">
+      <node concept="2KyDCi" id="2kMEKexN5U" role="fTz2r">
+        <property role="TrG5h" value="Internet" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5V" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeo" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNep" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeq" role="3VMn$3">
+              <property role="3VMn$Y" value="Internet" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNer" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNes" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNee" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN5Y" role="fTz2r">
+        <property role="TrG5h" value="Public" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5Z" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNey" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNez" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe$" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe_" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNeg" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN64" role="fTz2r">
+        <property role="TrG5h" value="Public Cloud" />
+        <property role="qSweV" value="60" />
+        <node concept="3VMn$a" id="2kMEKexN65" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeE" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeF" role="3VMn$3">
+              <property role="3VMn$Y" value="Public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeG" role="3VMn$3">
+              <property role="3VMn$Y" value="cloud" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeH" role="3VMn$3">
+              <property role="3VMn$Y" value="service" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNei" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6c" role="fTz2r">
+        <property role="TrG5h" value="Trusted Partner" />
+        <property role="qSweV" value="80" />
+        <node concept="3VMn$a" id="2kMEKexN6d" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeM" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeN" role="3VMn$3">
+              <property role="3VMn$Y" value="Vetted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeO" role="3VMn$3">
+              <property role="3VMn$Y" value="and" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeP" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeQ" role="3VMn$3">
+              <property role="3VMn$Y" value="partner" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNek" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6m" role="fTz2r">
+        <property role="TrG5h" value="Private Secured" />
+        <property role="qSweV" value="100" />
+        <node concept="3VMn$a" id="2kMEKexN6n" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeW" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeX" role="3VMn$3">
+              <property role="3VMn$Y" value="A" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeY" role="3VMn$3">
+              <property role="3VMn$Y" value="secured" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeZ" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf0" role="3VMn$3">
+              <property role="3VMn$Y" value="within" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf1" role="3VMn$3">
+              <property role="3VMn$Y" value="a" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf2" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf3" role="3VMn$3">
+              <property role="3VMn$Y" value="private" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf4" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNem" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+    </node>
+    <node concept="2O4_Cn" id="3UUEFQaLz58" role="2O4_UX">
+      <node concept="2O6gX2" id="3UUEFQaLz5a" role="2O4_Cm">
+        <property role="2O6gL_" value="0" />
+        <node concept="3VMn$a" id="3UUEFQaLz5b" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5e" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5g" role="2O4_Cm">
+        <property role="2O6gL_" value="20" />
+        <node concept="3VMn$a" id="3UUEFQaLz5h" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5s" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5u" role="2O4_Cm">
+        <property role="2O6gL_" value="40" />
+        <node concept="3VMn$a" id="3UUEFQaLz5v" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5C" role="E7tE9">
+          <property role="1iTho6" value="FFFF99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5E" role="2O4_Cm">
+        <property role="2O6gL_" value="60" />
+        <node concept="3VMn$a" id="3UUEFQaLz5F" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5R" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5T" role="2O4_Cm">
+        <property role="2O6gL_" value="80" />
+        <node concept="3VMn$a" id="3UUEFQaLz5U" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz69" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz6b" role="2O4_Cm">
+        <property role="2O6gL_" value="100" />
+        <node concept="3VMn$a" id="3UUEFQaLz6c" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz6u" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -23,7 +23,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -59,7 +59,15 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="ea36efc9-242c-402d-9cd6-9b37c96aac34(ISOComposition)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -68,6 +76,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/ISO21434/ISOComposition/models/MethodConfiguration.mps
+++ b/ISO21434/ISOComposition/models/MethodConfiguration.mps
@@ -9,6 +9,9 @@
   </imports>
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
+      <concept id="8140327204155191530" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelsDefinition" flags="ng" index="fTz2s">
+        <child id="8140327204155191533" name="levels" index="fTz2r" />
+      </concept>
       <concept id="4497791247486336887" name="de.itemis.ysec.methodConfiguration.structure.DamageClass" flags="ng" index="i8Y8S" />
       <concept id="7480212422238926806" name="de.itemis.ysec.methodConfiguration.structure.ImpactScale" flags="ng" index="2nNfD6">
         <property id="7480212422238960135" name="value" index="2nMRun" />
@@ -35,11 +38,24 @@
         <property id="8045787582102992758" name="value" index="uPLpr" />
       </concept>
       <concept id="5265403561757222969" name="de.itemis.ysec.methodConfiguration.structure.Stakeholder" flags="ng" index="CzX2t" />
+      <concept id="848894267652668100" name="de.itemis.ysec.methodConfiguration.structure.TrustLevel" flags="ng" index="2KyDCi">
+        <property id="7152850790341018718" name="value" index="qSweV" />
+      </concept>
       <concept id="227120341090634910" name="de.itemis.ysec.methodConfiguration.structure.AFLsDefinition" flags="ng" index="KRYwx">
         <child id="227120341090909991" name="values" index="KQXIo" />
       </concept>
       <concept id="227120341090635007" name="de.itemis.ysec.methodConfiguration.structure.AttackFeasibilityLevel" flags="ng" index="KRYx0">
         <property id="227120341090910048" name="minimalValue" index="KQXJv" />
+      </concept>
+      <concept id="848894267651765571" name="de.itemis.ysec.methodConfiguration.structure.TrustModel" flags="ng" index="2KY5ml">
+        <child id="8140327204155204736" name="trustLevelsDefinition" index="fTIjQ" />
+        <child id="4520112907071583232" name="trustBoundaryCategoriesDefinition" index="2O4_UX" />
+      </concept>
+      <concept id="4520112907071582378" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategoriesDefinition" flags="ng" index="2O4_Cn">
+        <child id="4520112907071582379" name="categories" index="2O4_Cm" />
+      </concept>
+      <concept id="4520112907071235583" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategory" flags="ng" index="2O6gX2">
+        <property id="4520112907071235800" name="value" index="2O6gL_" />
       </concept>
       <concept id="1756525789544303273" name="de.itemis.ysec.methodConfiguration.structure.DamagePotentialsDefinition" flags="ng" index="OYqhf">
         <child id="1756525789544303274" name="values" index="OYqhc" />
@@ -6418,6 +6434,176 @@
   <node concept="3XX4$o" id="65pzHM4F7u5">
     <property role="TrG5h" value="ISO/SAE 21434 Terminology" />
     <ref role="3iLw6d" to="si5v:3xoDER5IZYq" resolve="ISO/SAE 21434 Terminology (Default)" />
+  </node>
+  <node concept="2KY5ml" id="2kMEKexN5T">
+    <property role="TrG5h" value="Trust Model" />
+    <node concept="fTz2s" id="73Sg7pZ8d6f" role="fTIjQ">
+      <node concept="2KyDCi" id="2kMEKexN5U" role="fTz2r">
+        <property role="TrG5h" value="Internet" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5V" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeo" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNep" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeq" role="3VMn$3">
+              <property role="3VMn$Y" value="Internet" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNer" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNes" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNee" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN5Y" role="fTz2r">
+        <property role="TrG5h" value="Public" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5Z" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNey" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNez" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe$" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe_" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNeg" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN64" role="fTz2r">
+        <property role="TrG5h" value="Public Cloud" />
+        <property role="qSweV" value="60" />
+        <node concept="3VMn$a" id="2kMEKexN65" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeE" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeF" role="3VMn$3">
+              <property role="3VMn$Y" value="Public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeG" role="3VMn$3">
+              <property role="3VMn$Y" value="cloud" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeH" role="3VMn$3">
+              <property role="3VMn$Y" value="service" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNei" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6c" role="fTz2r">
+        <property role="TrG5h" value="Trusted Partner" />
+        <property role="qSweV" value="80" />
+        <node concept="3VMn$a" id="2kMEKexN6d" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeM" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeN" role="3VMn$3">
+              <property role="3VMn$Y" value="Vetted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeO" role="3VMn$3">
+              <property role="3VMn$Y" value="and" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeP" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeQ" role="3VMn$3">
+              <property role="3VMn$Y" value="partner" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNek" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6m" role="fTz2r">
+        <property role="TrG5h" value="Private Secured" />
+        <property role="qSweV" value="100" />
+        <node concept="3VMn$a" id="2kMEKexN6n" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeW" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeX" role="3VMn$3">
+              <property role="3VMn$Y" value="A" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeY" role="3VMn$3">
+              <property role="3VMn$Y" value="secured" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeZ" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf0" role="3VMn$3">
+              <property role="3VMn$Y" value="within" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf1" role="3VMn$3">
+              <property role="3VMn$Y" value="a" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf2" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf3" role="3VMn$3">
+              <property role="3VMn$Y" value="private" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf4" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNem" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+    </node>
+    <node concept="2O4_Cn" id="3UUEFQaLz58" role="2O4_UX">
+      <node concept="2O6gX2" id="3UUEFQaLz5a" role="2O4_Cm">
+        <property role="2O6gL_" value="0" />
+        <node concept="3VMn$a" id="3UUEFQaLz5b" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5e" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5g" role="2O4_Cm">
+        <property role="2O6gL_" value="20" />
+        <node concept="3VMn$a" id="3UUEFQaLz5h" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5s" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5u" role="2O4_Cm">
+        <property role="2O6gL_" value="40" />
+        <node concept="3VMn$a" id="3UUEFQaLz5v" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5C" role="E7tE9">
+          <property role="1iTho6" value="FFFF99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5E" role="2O4_Cm">
+        <property role="2O6gL_" value="60" />
+        <node concept="3VMn$a" id="3UUEFQaLz5F" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5R" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5T" role="2O4_Cm">
+        <property role="2O6gL_" value="80" />
+        <node concept="3VMn$a" id="3UUEFQaLz5U" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz69" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz6b" role="2O4_Cm">
+        <property role="2O6gL_" value="100" />
+        <node concept="3VMn$a" id="3UUEFQaLz6c" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz6u" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -62,8 +62,16 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="ea36efc9-242c-402d-9cd6-9b37c96aac34(ISOComposition)" version="0" />
     <module reference="8cdc011b-33c1-488b-ab6f-ecd326955614(ISOExample)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -72,6 +80,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -344,7 +344,7 @@
       </concept>
       <concept id="6495719316977867921" name="com.moraad.core.structure.ConceptElement" flags="ng" index="3bfFbs">
         <child id="6495719316977867929" name="requirements" index="3bfFbk" />
-        <child id="6495719316977867928" name="risk" index="3bfFbl" />
+        <child id="6495719316977867928" name="risks" index="3bfFbl" />
       </concept>
       <concept id="709149415121875681" name="com.moraad.core.structure.DamageCriteriaForClassAssignments" flags="ng" index="3cP9l3">
         <child id="709149415121878132" name="damageCriteriaAssignments" index="3cP9Jm" />

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -160,7 +160,9 @@
       <concept id="2129184553237592677" name="com.moraad.reports.structure.ChannelsTableReportItem" flags="ng" index="3xttxO" />
       <concept id="2129184553237375048" name="com.moraad.reports.structure.FunctionTableReportItem" flags="ng" index="3xuwDp" />
       <concept id="2129184553228409378" name="com.moraad.reports.structure.FuncAssignmentSimpleTableReportItem" flags="ng" index="3xSvwN" />
-      <concept id="2789775304370122439" name="com.moraad.reports.structure.ChecklistReportItem" flags="ng" index="3y_2Gs" />
+      <concept id="2789775304370122439" name="com.moraad.reports.structure.ChecklistReportItem" flags="ng" index="3y_2Gs">
+        <child id="8310706830414723559" name="checklist" index="3S7roN" />
+      </concept>
       <concept id="2195216638865431028" name="com.moraad.reports.structure.DamageAndThreatScenariosReportItem" flags="ng" index="3yVM0i" />
       <concept id="8588388912954219383" name="com.moraad.reports.structure.DamageScenarioTableReportItem" flags="ng" index="3UIwP1">
         <property id="3063787601294055561" name="excludeImpactScale" index="gT1Cu" />
@@ -246,6 +248,9 @@
       </concept>
     </language>
     <language id="24e88a55-f0b5-4dc5-9077-49730e920865" name="de.itemis.ysec.checklist">
+      <concept id="2733645172414747772" name="de.itemis.ysec.checklist.structure.ChecklistRef" flags="ng" index="AksYL">
+        <reference id="2733645172414747777" name="target" index="AksXc" />
+      </concept>
       <concept id="6217398072109638567" name="de.itemis.ysec.checklist.structure.ChecklistItem" flags="ng" index="2H0S4X">
         <child id="4258253476795566208" name="rationale" index="3GS99T" />
       </concept>
@@ -3651,6 +3656,11 @@
     <node concept="3xttxO" id="1k$QKsQS93e" role="yp9Ks" />
     <node concept="ymko6" id="1k$QKsQS9zN" role="yp9Ks" />
     <node concept="3y_2Gs" id="1VvRu3aCB92" role="yp9Ks" />
+    <node concept="3y_2Gs" id="7dlzXibGPiG" role="yp9Ks">
+      <node concept="AksYL" id="7dlzXibGPkn" role="3S7roN">
+        <ref role="AksXc" node="3L93fJiu$EI" resolve="UN R155 Threats" />
+      </node>
+    </node>
     <node concept="ymko6" id="1VvRu3aCB6p" role="yp9Ks" />
     <node concept="3Wlq9l" id="1VvRu3aCBd4" role="yp9Ks" />
     <node concept="3Wlq9l" id="1YUD_SAIGfm" role="yp9Ks">

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -11,6 +11,7 @@
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
       <concept id="8278271381845378605" name="de.itemis.ysec.methodConfiguration.structure.AFLRef" flags="ng" index="1vNPnr" />
+      <concept id="8849129041839306048" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelRef" flags="ng" index="3GCHUU" />
       <concept id="6006699537885391512" name="de.itemis.ysec.methodConfiguration.structure.SecurityGoalClassRef" flags="ng" index="3RtnZZ" />
     </language>
     <language id="77390b0e-ab69-4de7-a036-d557f81b479e" name="de.itemis.ysec.catalog.technologies">
@@ -418,11 +419,19 @@
     <language id="c1497963-7ffd-4da0-9a4d-74675c5ab7e2" name="com.moraad.components">
       <concept id="4903305818773966639" name="com.moraad.components.structure.TOEChunk" flags="ng" index="2lbcm6" />
       <concept id="4903305818773971546" name="com.moraad.components.structure.TOEComponent" flags="ng" index="2lbezN">
+        <child id="7296163292644697544" name="trustZone" index="345swj" />
         <child id="1808727333797819112" name="subComponents" index="1b_L45" />
         <child id="1808727333797819114" name="storedData" index="1b_L47" />
       </concept>
       <concept id="4903305818773998197" name="com.moraad.components.structure.ITOEElementContainer" flags="ng" index="2lbk3s">
         <child id="4903305818773998200" name="elements" index="2lbk3h" />
+      </concept>
+      <concept id="5693834772128144381" name="com.moraad.components.structure.TrustZoneChunk" flags="ng" index="2lsSHN">
+        <child id="5693834772129560276" name="trustZones" index="2ly2pq" />
+      </concept>
+      <concept id="5693834772129554889" name="com.moraad.components.structure.TrustZone" flags="ng" index="2ly357">
+        <child id="5693834772130897929" name="subZones" index="2lDr27" />
+        <child id="8849129041839306097" name="trustLevel" index="3GCHUb" />
       </concept>
       <concept id="3911760519739995188" name="com.moraad.components.structure.SystemDiagram" flags="ng" index="2ndE_3">
         <property id="1514418932059619330" name="hierarchyLevels" index="2zzwJW" />
@@ -440,6 +449,8 @@
       <concept id="5188113475686638955" name="com.moraad.components.structure.TOEData" flags="ng" index="2zhWjs" />
       <concept id="2560071392251274778" name="com.moraad.components.structure.TOEFunction" flags="ng" index="Hgtl4" />
       <concept id="8237891392911108311" name="com.moraad.components.structure.TOEFunctionRef" flags="ng" index="IT3p4" />
+      <concept id="812298049876156433" name="com.moraad.components.structure.TrustZoneContentSelector" flags="ng" index="31QrNk" />
+      <concept id="7296163292644697473" name="com.moraad.components.structure.TrustZoneRef" flags="ng" index="345sxq" />
       <concept id="8675533035673365864" name="com.moraad.components.structure.FunctionAssignment" flags="ng" index="347S8W" />
       <concept id="1210691741201230377" name="com.moraad.components.structure.IFunctionAssignable" flags="ng" index="1e0lug">
         <child id="6569433384300427095" name="assignedFunctions" index="lYIuc" />
@@ -559,6 +570,9 @@
           <property role="TrG5h" value="NavECU" />
           <property role="DVXpC" value="Navigation ECU" />
           <node concept="3VMn$a" id="7bZZv_jRVp4" role="2JHqPs" />
+          <node concept="345sxq" id="7tyS2pKKZPc" role="345swj">
+            <ref role="122Z_O" node="7tyS2pKKZOv" resolve="TZ.6" />
+          </node>
         </node>
         <node concept="2lbezN" id="1eUj96eGPLA" role="1b_L45">
           <property role="TrG5h" value="GateECU" />
@@ -567,6 +581,9 @@
             <ref role="122Z_O" node="7gwHXNztHdJ" resolve="WhtLst" />
           </node>
           <node concept="3VMn$a" id="7bZZv_jRVp5" role="2JHqPs" />
+          <node concept="345sxq" id="7tyS2pKKZPk" role="345swj">
+            <ref role="122Z_O" node="7tyS2pKKZOL" resolve="TZ.8" />
+          </node>
         </node>
         <node concept="2lbezN" id="1eUj96eGPMi" role="1b_L45">
           <property role="TrG5h" value="HLsys" />
@@ -575,6 +592,9 @@
             <property role="TrG5h" value="HLswit" />
             <property role="DVXpC" value="Headlamp switch" />
             <node concept="3VMn$a" id="7bZZv_jRVp7" role="2JHqPs" />
+            <node concept="345sxq" id="7tyS2pKKZPm" role="345swj">
+              <ref role="122Z_O" node="7tyS2pKKZND" resolve="TZ.5" />
+            </node>
           </node>
           <node concept="2lbezN" id="1eUj96eGPN2" role="1b_L45">
             <property role="TrG5h" value="BodyECU" />
@@ -599,13 +619,22 @@
             <node concept="3VMn$a" id="7bZZv_jRVp9" role="2JHqPs" />
           </node>
           <node concept="3VMn$a" id="7bZZv_jRVp6" role="2JHqPs" />
+          <node concept="345sxq" id="7tyS2pKKZPe" role="345swj">
+            <ref role="122Z_O" node="7tyS2pKKZN_" resolve="TZ.4" />
+          </node>
         </node>
         <node concept="3VMn$a" id="7bZZv_jRVp3" role="2JHqPs" />
+        <node concept="345sxq" id="7tyS2pKKZPi" role="345swj">
+          <ref role="122Z_O" node="7tyS2pKKZNp" resolve="TZ.1" />
+        </node>
       </node>
       <node concept="2lbezN" id="2VUdYcMmrJu" role="1b_L45">
         <property role="TrG5h" value="ExtECU" />
         <property role="DVXpC" value="External ECUs" />
         <node concept="3VMn$a" id="7bZZv_jRVpa" role="2JHqPs" />
+        <node concept="345sxq" id="7tyS2pKKZPg" role="345swj">
+          <ref role="122Z_O" node="7tyS2pKKZNx" resolve="TZ.3" />
+        </node>
       </node>
       <node concept="3VMn$a" id="7bZZv_jRVdk" role="2JHqPs">
         <node concept="3VMn$0" id="7bZZv_jRVdl" role="3VMn$6">
@@ -4955,6 +4984,75 @@
       </node>
     </node>
     <node concept="3dGa_S" id="1xzt3hRBlIL" role="2xH1$J" />
+  </node>
+  <node concept="2lsSHN" id="7tyS2pKKZNn">
+    <property role="3GE5qa" value="Item Definition" />
+    <property role="TrG5h" value="Trust Zones" />
+    <node concept="31QrNk" id="7tyS2pKKZNo" role="2xH1$J" />
+    <node concept="2ly357" id="7tyS2pKKZNp" role="2ly2pq">
+      <property role="DVXpC" value="Internet" />
+      <property role="TrG5h" value="TZ.1" />
+      <node concept="3VMn$a" id="7tyS2pKKZNq" role="2JHqPs" />
+      <node concept="3GCHUU" id="7tyS2pKKZNs" role="3GCHUb">
+        <ref role="122Z_O" to="xz8e:2kMEKexN5U" resolve="Internet" />
+      </node>
+      <node concept="2ly357" id="7tyS2pKKZNt" role="2lDr27">
+        <property role="DVXpC" value="Public" />
+        <property role="TrG5h" value="TZ.2" />
+        <node concept="3VMn$a" id="7tyS2pKKZNu" role="2JHqPs" />
+        <node concept="3GCHUU" id="7tyS2pKKZNw" role="3GCHUb">
+          <ref role="122Z_O" to="xz8e:2kMEKexN5Y" resolve="Public" />
+        </node>
+        <node concept="2ly357" id="7tyS2pKKZNx" role="2lDr27">
+          <property role="DVXpC" value="Public Cloud" />
+          <property role="TrG5h" value="TZ.3" />
+          <node concept="3VMn$a" id="7tyS2pKKZNy" role="2JHqPs" />
+          <node concept="3GCHUU" id="7tyS2pKKZN$" role="3GCHUb">
+            <ref role="122Z_O" to="xz8e:2kMEKexN64" resolve="Public Cloud" />
+          </node>
+          <node concept="2ly357" id="7tyS2pKKZN_" role="2lDr27">
+            <property role="DVXpC" value="Headlamp System Supplier" />
+            <property role="TrG5h" value="TZ.4" />
+            <node concept="3VMn$a" id="7tyS2pKKZNA" role="2JHqPs" />
+            <node concept="3GCHUU" id="7tyS2pKKZNC" role="3GCHUb">
+              <ref role="122Z_O" to="xz8e:2kMEKexN6c" resolve="Trusted Partner" />
+            </node>
+            <node concept="2ly357" id="7tyS2pKKZND" role="2lDr27">
+              <property role="DVXpC" value="Private Secured - Headlamp System" />
+              <property role="TrG5h" value="TZ.5" />
+              <node concept="3VMn$a" id="7tyS2pKKZNE" role="2JHqPs" />
+              <node concept="3GCHUU" id="7tyS2pKKZNG" role="3GCHUb">
+                <ref role="122Z_O" to="xz8e:2kMEKexN6m" resolve="Private Secured" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ly357" id="7tyS2pKKZOv" role="2lDr27">
+            <property role="DVXpC" value="Navigation ECU Supplier" />
+            <property role="TrG5h" value="TZ.6" />
+            <node concept="3VMn$a" id="7tyS2pKKZOw" role="2JHqPs" />
+            <node concept="3GCHUU" id="7tyS2pKKZOx" role="3GCHUb">
+              <ref role="122Z_O" to="xz8e:2kMEKexN6c" resolve="Trusted Partner" />
+            </node>
+            <node concept="2ly357" id="7tyS2pKKZOy" role="2lDr27">
+              <property role="DVXpC" value="Private Secured - Navigation ECU" />
+              <property role="TrG5h" value="TZ.7" />
+              <node concept="3VMn$a" id="7tyS2pKKZOz" role="2JHqPs" />
+              <node concept="3GCHUU" id="7tyS2pKKZO$" role="3GCHUb">
+                <ref role="122Z_O" to="xz8e:2kMEKexN6m" resolve="Private Secured" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ly357" id="7tyS2pKKZOL" role="2lDr27">
+            <property role="DVXpC" value="Private Secured" />
+            <property role="TrG5h" value="TZ.8" />
+            <node concept="3VMn$a" id="7tyS2pKKZOM" role="2JHqPs" />
+            <node concept="3GCHUU" id="7tyS2pKKZON" role="3GCHUb">
+              <ref role="122Z_O" to="xz8e:2kMEKexN6m" resolve="Private Secured" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -454,6 +454,10 @@
       <concept id="7050052209593327466" name="com.moraad.components.structure.TOEComponentContentSelector" flags="ng" index="2x4$Tb" />
       <concept id="7050052209593327468" name="com.moraad.components.structure.TOEChannelContentSelector" flags="ng" index="2x4$Td" />
       <concept id="5188113475688114801" name="com.moraad.components.structure.FunctionAssignmentChunk" flags="ng" index="2zckJ6">
+        <property id="8675533035648326051" name="showSmartViewByDefault" index="32ArrR" />
+        <child id="2903910728803987" name="functions" index="1Bunu4" />
+        <child id="2903910728803983" name="smartFunctionAssignables" index="1Bunuo" />
+        <child id="2903910728803980" name="functionAssignables" index="1Bunur" />
         <child id="2094790996039355713" name="smartFuncAssignments" index="3KzJKe" />
       </concept>
       <concept id="5188113475686638955" name="com.moraad.components.structure.TOEData" flags="ng" index="2zhWjs" />
@@ -474,6 +478,10 @@
         <reference id="4250072277178649488" name="target" index="3$0O6B" />
       </concept>
       <concept id="4250072277178649596" name="com.moraad.components.structure.TOEComponentRef" flags="ng" index="3$0O7b" />
+      <concept id="2903910728542993" name="com.moraad.components.structure.SmartFunctionAssignable" flags="ng" index="1BpnC6">
+        <reference id="2903910728542996" name="origin" index="1BpnC3" />
+        <child id="2903910728542994" name="data" index="1BpnC5" />
+      </concept>
       <concept id="9034427618896218585" name="com.moraad.components.structure.TOEDataFlowRef" flags="ng" index="3Kajnk" />
       <concept id="9034427618896207423" name="com.moraad.components.structure.TOEDataFlow" flags="ng" index="3Kau8M">
         <reference id="549470471296403036" name="targetRef" index="27$5CB" />
@@ -1836,6 +1844,43 @@
   </node>
   <node concept="2zckJ6" id="5wtRytMI6hA">
     <property role="3GE5qa" value="Item Definition" />
+    <property role="32ArrR" value="true" />
+    <node concept="3KzYab" id="1V484Ri7I6P" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGQ3O" resolve="OffMsg" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7I6O" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGQ3J" resolve="OnMsg" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7I6Q" role="1Bunur">
+      <ref role="122Z_O" node="7gwHXNztHdJ" resolve="WhtLst" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6L" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPN2" resolve="BodyECU" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6N" role="1Bunur">
+      <ref role="122Z_O" node="2VUdYcMmrJu" resolve="ExtECU" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6I" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPLA" resolve="GateECU" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6K" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPMF" resolve="HLswit" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6J" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPMi" resolve="HLsys" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6G" role="1Bunur">
+      <ref role="122Z_O" node="2VUdYcMmrAH" resolve="ItemBoundary" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6H" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPLj" resolve="NavECU" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6M" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPNr" resolve="PowSwitAct" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7I6F" role="1Bunur">
+      <ref role="122Z_O" node="5wtRytMI6ht" resolve="SYS" />
+    </node>
     <node concept="3KzJKc" id="1kMJkOan9PI" role="3KzJKe">
       <ref role="3KzJK7" node="1eUj96eGQ3O" resolve="OffMsg" />
       <ref role="3KzJK9" node="1eUj96eGQ6h" resolve="DF.6" />
@@ -1845,6 +1890,69 @@
       <ref role="3KzJK7" node="1eUj96eGQ3J" resolve="OnMsg" />
       <ref role="3KzJK9" node="1eUj96eGQ6h" resolve="DF.6" />
       <ref role="3KDv1v" node="5wtRytMI6Sb" resolve="OnFunc" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7I6T" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPOq" resolve="DF.1" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7I6U" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPUe" resolve="DF.4" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7I6R" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGQ6h" resolve="DF.6" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7I6S" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGQPv" resolve="DF.7" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7I6V" role="1Bunur">
+      <ref role="122Z_O" node="2VUdYcMmrSl" resolve="DF.8" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7I6B" role="1Bunur">
+      <ref role="122Z_O" node="75wqdiwEFag" resolve="Ch.1" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7I6C" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPOj" resolve="Ch.3" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7I6D" role="1Bunur">
+      <ref role="122Z_O" node="1eUj96eGPU7" resolve="Ch.6" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7I6E" role="1Bunur">
+      <ref role="122Z_O" node="2VUdYcMmrSh" resolve="Ch.7" />
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7I6X" role="1Bunuo">
+      <ref role="1BpnC3" node="1eUj96eGPLA" resolve="GateECU" />
+      <node concept="3KzYab" id="1V484Ri7I6W" role="1BpnC5">
+        <ref role="122Z_O" node="7gwHXNztHdJ" resolve="WhtLst" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7I73" role="1Bunuo">
+      <ref role="1BpnC3" node="1eUj96eGQ6h" resolve="DF.6" />
+      <node concept="3KzYab" id="1V484Ri7I72" role="1BpnC5">
+        <ref role="122Z_O" node="1eUj96eGQ3O" resolve="OffMsg" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7I75" role="1Bunuo">
+      <ref role="1BpnC3" node="1eUj96eGQPv" resolve="DF.7" />
+      <node concept="3KzYab" id="1V484Ri7I74" role="1BpnC5">
+        <ref role="122Z_O" node="1eUj96eGQ3O" resolve="OffMsg" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7I6Z" role="1Bunuo">
+      <ref role="1BpnC3" node="1eUj96eGQ6h" resolve="DF.6" />
+      <node concept="3KzYab" id="1V484Ri7I6Y" role="1BpnC5">
+        <ref role="122Z_O" node="1eUj96eGQ3J" resolve="OnMsg" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7I71" role="1Bunuo">
+      <ref role="1BpnC3" node="1eUj96eGQPv" resolve="DF.7" />
+      <node concept="3KzYab" id="1V484Ri7I70" role="1BpnC5">
+        <ref role="122Z_O" node="1eUj96eGQ3J" resolve="OnMsg" />
+      </node>
+    </node>
+    <node concept="IT3p4" id="1V484Ri7I76" role="1Bunu4">
+      <ref role="122Z_O" node="5wtRytMI6S9" resolve="OffFunc" />
+    </node>
+    <node concept="IT3p4" id="1V484Ri7I77" role="1Bunu4">
+      <ref role="122Z_O" node="5wtRytMI6Sb" resolve="OnFunc" />
     </node>
   </node>
   <node concept="2vPz$R" id="5wtRytMI6hB">

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -3815,7 +3815,7 @@
     </node>
   </node>
   <node concept="2H3I8p" id="3L93fJiu$EI">
-    <property role="TrG5h" value="UN R155 Threats " />
+    <property role="TrG5h" value="UN R155 Threats" />
     <property role="3F1M74" value="true" />
     <property role="3GE5qa" value="Checklists" />
     <node concept="2H0S5N" id="3L93fJiu$EJ" role="2H0S4$">
@@ -4052,7 +4052,7 @@
         <node concept="3VMn$a" id="5F0rLLZnk0k" role="3GS99T" />
       </node>
       <node concept="3GSqTS" id="3L93fJiu$FU" role="2H0S5D">
-        <property role="TrG5h" value="18" />
+        <property role="TrG5h" value="18 Devices connected to external interfaces e.g. USB ports, OBD port, used as a means to attack vehicle systems" />
       </node>
       <node concept="2H0S4X" id="3L93fJiu$FV" role="2H0S5D">
         <property role="TrG5h" value="External interfaces such as USB or other ports used as a point of attack, for example through code injection" />

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -53,6 +53,10 @@
       <concept id="1920997147008949188" name="com.moraad.suggestions.structure.RiskAssistantSelector" flags="ng" index="CEhHY" />
       <concept id="1920997147009089272" name="com.moraad.suggestions.structure.AssRiskSuggestionFactory" flags="ng" index="CENT2" />
       <concept id="8675225129845988701" name="com.moraad.suggestions.structure.AssDsThreatenedByTsSuggestionFactory" flags="ng" index="2FpSCn" />
+      <concept id="4155569431961189920" name="com.moraad.suggestions.structure.InteractionAssistantSelector" flags="ng" index="2IbN91" />
+      <concept id="4155569431961199169" name="com.moraad.suggestions.structure.AssInteractionSuggestionFactory" flags="ng" index="2IbQSw">
+        <reference id="4155569431963318236" name="context" index="2I3FIX" />
+      </concept>
       <concept id="1069594670716434985" name="com.moraad.suggestions.structure.AssConceptUpdateSuggestionFactory" flags="ng" index="2JoWM6" />
       <concept id="1069594670716328269" name="com.moraad.suggestions.structure.ConceptUpdateAssistantSelector" flags="ng" index="2JpmZy" />
       <concept id="1715757343547858166" name="com.moraad.suggestions.structure.ClaimCreationAssistantSelector" flags="ng" index="2LfSj0" />
@@ -108,6 +112,7 @@
       <concept id="2050517468709281410" name="com.moraad.reports.structure.AssetsAndDamageScenariosTableReportItem" flags="ng" index="ckFx4">
         <property id="8417410718506888096" name="showNonAssets" index="9YSRj" />
       </concept>
+      <concept id="8140327204157545254" name="com.moraad.reports.structure.TrustLevelsTableReportItem" flags="ng" index="fIxHg" />
       <concept id="288157383581295240" name="com.moraad.reports.structure.ImpactLevelsTableReportItem" flags="ng" index="kePWl" />
       <concept id="288157383577698444" name="com.moraad.reports.structure.SecurityPropertiesTableReportItem" flags="ng" index="ksrOh" />
       <concept id="2889406642063639953" name="com.moraad.reports.structure.IHaveRationale" flags="ng" index="nKFAp">
@@ -138,6 +143,7 @@
       </concept>
       <concept id="9125927369354634356" name="com.moraad.reports.structure.FeasibilityCategoriesTableReportItem" flags="ng" index="AK2Fz" />
       <concept id="9125927369345168869" name="com.moraad.reports.structure.ImpactCategoriesTableReportItem" flags="ng" index="DsbHM" />
+      <concept id="7513251049376197570" name="com.moraad.reports.structure.TrustZonesTableReportItem" flags="ng" index="2E8$n7" />
       <concept id="1488669593885577694" name="com.moraad.reports.structure.CommentReportItem" flags="ng" index="2JOk35">
         <property id="1488669593885577696" name="text" index="2JOk3V" />
       </concept>
@@ -159,6 +165,10 @@
       <concept id="2129184553237592667" name="com.moraad.reports.structure.DataFlowsTableReportItem" flags="ng" index="3xttxa" />
       <concept id="2129184553237592647" name="com.moraad.reports.structure.ComponentsTableReportItem" flags="ng" index="3xttxm" />
       <concept id="2129184553237592677" name="com.moraad.reports.structure.ChannelsTableReportItem" flags="ng" index="3xttxO" />
+      <concept id="2129184553237375058" name="com.moraad.reports.structure.IToeElementTableReportItem" flags="ng" index="3xuwD3">
+        <property id="760225772605925982" name="excludeCAL" index="3ZMjsh" />
+        <property id="760225772605925988" name="excludeTrustAssessment" index="3ZMjsF" />
+      </concept>
       <concept id="2129184553237375048" name="com.moraad.reports.structure.FunctionTableReportItem" flags="ng" index="3xuwDp" />
       <concept id="2129184553228409378" name="com.moraad.reports.structure.FuncAssignmentSimpleTableReportItem" flags="ng" index="3xSvwN" />
       <concept id="2789775304370122439" name="com.moraad.reports.structure.ChecklistReportItem" flags="ng" index="3y_2Gs">
@@ -3683,6 +3693,9 @@
     </node>
     <node concept="ymko6" id="1k$QKsQS8zI" role="yp9Ks" />
     <node concept="3xttxO" id="1k$QKsQS93e" role="yp9Ks" />
+    <node concept="3xttxO" id="7tyS2pKL2qM" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+    </node>
     <node concept="ymko6" id="1k$QKsQS9zN" role="yp9Ks" />
     <node concept="3y_2Gs" id="1VvRu3aCB92" role="yp9Ks" />
     <node concept="3y_2Gs" id="7dlzXibGPiG" role="yp9Ks">
@@ -3705,6 +3718,16 @@
     </node>
     <node concept="ymko6" id="1k$QKsQSa_b" role="yp9Ks" />
     <node concept="3xttxm" id="1k$QKsQSb68" role="yp9Ks" />
+    <node concept="3xttxm" id="7tyS2pKL2jo" role="yp9Ks">
+      <property role="3ZMjsF" value="true" />
+    </node>
+    <node concept="3xttxm" id="7tyS2pKL2ld" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+    </node>
+    <node concept="3xttxm" id="7tyS2pKL2n3" role="yp9Ks">
+      <property role="3ZMjsF" value="true" />
+      <property role="3ZMjsh" value="true" />
+    </node>
     <node concept="ymko6" id="1k$QKsQSbAD" role="yp9Ks" />
     <node concept="3dmGyN" id="1VvRu3aCBhc" role="yp9Ks" />
     <node concept="3dmGyN" id="1YUD_SAIGdQ" role="yp9Ks">
@@ -3783,8 +3806,21 @@
     <node concept="3yVM0i" id="1k$QKsQSlXK" role="yp9Ks" />
     <node concept="ymko6" id="1k$QKsQSmtg" role="yp9Ks" />
     <node concept="3xttxa" id="1k$QKsQSmXk" role="yp9Ks" />
+    <node concept="3xttxa" id="7tyS2pKL2dZ" role="yp9Ks">
+      <property role="3ZMjsF" value="true" />
+    </node>
+    <node concept="3xttxa" id="7tyS2pKL2fL" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+    </node>
+    <node concept="3xttxa" id="7tyS2pKL2h$" role="yp9Ks">
+      <property role="3ZMjsF" value="true" />
+      <property role="3ZMjsh" value="true" />
+    </node>
     <node concept="ymko6" id="1k$QKsQSnsY" role="yp9Ks" />
     <node concept="3xttx0" id="1k$QKsQSnXe" role="yp9Ks" />
+    <node concept="3xttx0" id="7tyS2pKL2ce" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+    </node>
     <node concept="ymko6" id="1k$QKsQSosU" role="yp9Ks" />
     <node concept="AK2Fz" id="1k$QKsQSoXe" role="yp9Ks" />
     <node concept="ymko6" id="1k$QKsQSpsW" role="yp9Ks" />
@@ -3793,6 +3829,9 @@
     <node concept="3xdgjh" id="1k$QKsQSqY_" role="yp9Ks" />
     <node concept="ymko6" id="1k$QKsQSrun" role="yp9Ks" />
     <node concept="3xuwDp" id="1k$QKsQSs04" role="yp9Ks" />
+    <node concept="3xuwDp" id="7tyS2pKL2oU" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+    </node>
     <node concept="ymko6" id="1k$QKsQSsvK" role="yp9Ks" />
     <node concept="2SZOu" id="1VvRu3aCBw1" role="yp9Ks" />
     <node concept="2SZOu" id="1YUD_SAIGip" role="yp9Ks">
@@ -3849,6 +3888,10 @@
       <property role="3CKxzC" value="true" />
     </node>
     <node concept="ymko6" id="1VvRu3aCC8u" role="yp9Ks" />
+    <node concept="fIxHg" id="7tyS2pKL23_" role="yp9Ks" />
+    <node concept="ymko6" id="7tyS2pKL25i" role="yp9Ks" />
+    <node concept="2E8$n7" id="7tyS2pKL28J" role="yp9Ks" />
+    <node concept="ymko6" id="7tyS2pKL2au" role="yp9Ks" />
     <node concept="2JOk35" id="1k$QKsQTm2C" role="yp9Ks">
       <property role="2JOk3V" value="Below you see the current &quot;default&quot; Control Scenario." />
     </node>
@@ -5049,6 +5092,434 @@
             <node concept="3GCHUU" id="7tyS2pKKZON" role="3GCHUb">
               <ref role="122Z_O" to="xz8e:2kMEKexN6m" resolve="Private Secured" />
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2Q15JU" id="7tyS2pKL1Od">
+    <property role="3GE5qa" value="Security Analysis.Assistants" />
+    <node concept="2IbQSw" id="7tyS2pKL1Oi" role="2Q$E0J">
+      <ref role="2I3FIX" node="2VUdYcMmrSl" resolve="DF.8" />
+      <node concept="3aHhih" id="7tyS2pKL1Ov" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Oy" role="3aHmvd">
+          <ref role="2ClQv0" node="2VUdYcMmrSl" resolve="DF.8" />
+          <node concept="k5JqA" id="7tyS2pKL1OA" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="2VUdYcMmrSl" resolve="DF.8" />
+            <node concept="17LMZa" id="7tyS2pKL1OB" role="lGtFl" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1OD" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="2VUdYcMmrSl" resolve="DF.8" />
+            <node concept="17LMZa" id="7tyS2pKL1OE" role="lGtFl" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1OM" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="2VUdYcMmrSl" resolve="DF.8" />
+            <node concept="17LMZa" id="7tyS2pKL1ON" role="lGtFl" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1OJ" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="2VUdYcMmrSl" resolve="DF.8" />
+            <node concept="17LMZa" id="7tyS2pKL1OK" role="lGtFl" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Oz" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="2VUdYcMmrSl" resolve="DF.8" />
+            <node concept="17LMZa" id="7tyS2pKL1O$" role="lGtFl" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1OG" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="2VUdYcMmrSl" resolve="DF.8" />
+            <node concept="17LMZa" id="7tyS2pKL1OH" role="lGtFl" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1Ow" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1SG" role="3aHmvd">
+          <ref role="2ClQv0" node="2VUdYcMmrJu" resolve="ExtECU" />
+          <node concept="k5JqA" id="7tyS2pKL1SI" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="2VUdYcMmrJu" resolve="ExtECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1SK" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="2VUdYcMmrJu" resolve="ExtECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1SH" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="2VUdYcMmrJu" resolve="ExtECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1SJ" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="2VUdYcMmrJu" resolve="ExtECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1Ox" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1SQ" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPLA" resolve="GateECU" />
+          <node concept="k5Jqw" id="7tyS2pKL1ST" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1SU" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTKQs" resolve="TS.2" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1SW" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1SR" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1SS" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTKQ$" resolve="TS.3" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1SV" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1Og" role="2Q$E0J">
+      <ref role="2I3FIX" node="1eUj96eGPOq" resolve="DF.1" />
+      <node concept="3aHhih" id="7tyS2pKL1T4" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1T7" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPOq" resolve="DF.1" />
+          <node concept="k5JqA" id="7tyS2pKL1T9" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="1eUj96eGPOq" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Ta" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPOq" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Td" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="1eUj96eGPOq" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Tc" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPOq" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1T8" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPOq" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Tb" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPOq" resolve="DF.1" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1T5" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Tl" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPLj" resolve="NavECU" />
+          <node concept="k5JqA" id="7tyS2pKL1Tn" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPLj" resolve="NavECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Tp" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPLj" resolve="NavECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Tm" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPLj" resolve="NavECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1To" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPLj" resolve="NavECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1T6" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Tv" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPLA" resolve="GateECU" />
+          <node concept="k5Jqw" id="7tyS2pKL1Ty" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1Tz" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTKQs" resolve="TS.2" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1T_" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1Tw" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1Tx" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTKQ$" resolve="TS.3" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1T$" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1Oh" role="2Q$E0J">
+      <ref role="2I3FIX" node="1eUj96eGPUe" resolve="DF.4" />
+      <node concept="3aHhih" id="7tyS2pKL1TH" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1TK" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPUe" resolve="DF.4" />
+          <node concept="k5JqA" id="7tyS2pKL1TM" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="1eUj96eGPUe" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1TN" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPUe" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1TQ" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="1eUj96eGPUe" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1TP" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPUe" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1TL" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPUe" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1TO" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPUe" resolve="DF.4" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1TI" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1TY" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPMF" resolve="HLswit" />
+          <node concept="k5JqA" id="7tyS2pKL1U0" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPMF" resolve="HLswit" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1U2" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPMF" resolve="HLswit" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1TZ" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPMF" resolve="HLswit" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1U1" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPMF" resolve="HLswit" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1TJ" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1U8" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPN2" resolve="BodyECU" />
+          <node concept="k5JqA" id="7tyS2pKL1Ua" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Uc" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1U9" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Ub" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1Of" role="2Q$E0J">
+      <ref role="2I3FIX" node="1eUj96eGQPv" resolve="DF.7" />
+      <node concept="3aHhih" id="7tyS2pKL1Ui" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Ul" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGQPv" resolve="DF.7" />
+          <node concept="k5JqA" id="7tyS2pKL1Un" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="1eUj96eGQPv" resolve="DF.7" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Uo" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGQPv" resolve="DF.7" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Ur" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="1eUj96eGQPv" resolve="DF.7" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Uq" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGQPv" resolve="DF.7" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Um" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGQPv" resolve="DF.7" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Up" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGQPv" resolve="DF.7" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1Uj" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Uz" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPLA" resolve="GateECU" />
+          <node concept="k5Jqw" id="7tyS2pKL1UA" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1UB" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTKQs" resolve="TS.2" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1UD" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1U$" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1U_" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTKQ$" resolve="TS.3" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1UC" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPLA" resolve="GateECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1Uk" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1UL" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          <node concept="k5JqA" id="7tyS2pKL1UN" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1UP" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1UM" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1UO" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbN91" id="7tyS2pKL1Oc" role="kmFqQ" />
+    <node concept="2IbQSw" id="7tyS2pKL1Oe" role="2Q$E0J">
+      <ref role="2I3FIX" node="1eUj96eGQ6h" resolve="DF.6" />
+      <node concept="3aHhih" id="7tyS2pKL1UV" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1UY" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGQ6h" resolve="DF.6" />
+          <node concept="k5JqA" id="7tyS2pKL1V0" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="1eUj96eGQ6h" resolve="DF.6" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1V1" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGQ6h" resolve="DF.6" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1V4" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="1eUj96eGQ6h" resolve="DF.6" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1V3" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGQ6h" resolve="DF.6" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1UZ" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGQ6h" resolve="DF.6" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1V2" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGQ6h" resolve="DF.6" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1UW" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Vc" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPN2" resolve="BodyECU" />
+          <node concept="k5JqA" id="7tyS2pKL1Ve" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Vg" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Vd" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Vf" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPN2" resolve="BodyECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1UX" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Vm" role="3aHmvd">
+          <ref role="2ClQv0" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          <node concept="k5JqA" id="7tyS2pKL1Vo" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Vq" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Vn" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Vp" role="2QGid4">
+            <ref role="2ClRH1" to="julz:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="1eUj96eGPNr" resolve="PowSwitAct" />
           </node>
         </node>
       </node>

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -4277,21 +4277,27 @@
         <property role="133MFP" value="" />
         <node concept="2Q16Lc" id="501$dK$SxaP" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTKQk" resolve="TS.1" />
-          <node concept="pcNHv" id="2ggMdWXzjpI" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$s1" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1eUj96eGRhm" resolve="R.2" />
             <ref role="2Dj$GC" node="60wEthBTKQk" resolve="TS.1" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SxaR" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTKQs" resolve="TS.2" />
-          <node concept="pcNHv" id="2ggMdWXzjpQ" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$s9" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1eUj96eGRhq" resolve="R.3" />
             <ref role="2Dj$GC" node="60wEthBTKQs" resolve="TS.2" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SxaT" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTKQ$" resolve="TS.3" />
-          <node concept="pcNHv" id="2ggMdWXzjpY" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$sh" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="6IMAd$NiG4n" resolve="R.1" />
             <ref role="2Dj$GC" node="60wEthBTKQ$" resolve="TS.3" />
           </node>

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -63,8 +63,16 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="e5c88256-a8e9-4a75-9ca4-4863fca0d461(ExampleAnalysis)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -73,6 +81,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -1856,27 +1856,27 @@
         </node>
         <node concept="2Q16Lc" id="501$dK$S_Ry" role="3aHmvd">
           <ref role="2ClQv0" node="702oElbSw2w" resolve="DS.2" />
-          <node concept="pcMM7" id="501$dK$S_Rz" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKEyKg" role="2QGid4">
             <property role="2yT22K" value="WL (CON, INT) ==&gt; (Data transferedBy Data Flow) NavFav (CON)" />
             <property role="2yT22M" value="WL: Wireless Link to Backend (CON, INT) ==&gt; (Data transferedBy Data Flow) NavFav: Favorite Navigation Destinations (CON)" />
             <ref role="2ClRH1" node="60wEthBTL2u" resolve="TS.1" />
             <ref role="2Dj$GC" node="702oElbSw2w" resolve="DS.2" />
-            <node concept="2C31c$" id="501$dK$S_R$" role="2QGGmO">
+            <node concept="2C31c$" id="7tyS2pKEyKh" role="2QGGmO">
               <ref role="2C31c_" node="5W_1Y9DMIW8" resolve="NavFav" />
             </node>
-            <node concept="2C31c$" id="501$dK$S_R_" role="2QGGmO">
+            <node concept="2C31c$" id="7tyS2pKEyKi" role="2QGGmO">
               <ref role="2C31c_" node="7UMEm_NKmKz" resolve="WL" />
             </node>
           </node>
-          <node concept="pcNHv" id="5hdoB45M$gY" role="2QGid4">
+          <node concept="pcMM7" id="7tyS2pKEyKj" role="2QGid4">
             <property role="2yT22K" value="GW (CON, INT) ==&gt; (Data processedBy Component) NavFav (CON)" />
             <property role="2yT22M" value="GW: Gateway (CON, INT) ==&gt; (Data processedBy Component) NavFav: Favorite Navigation Destinations (CON)" />
             <ref role="2ClRH1" node="60wEthBTL2A" resolve="TS.2" />
             <ref role="2Dj$GC" node="702oElbSw2w" resolve="DS.2" />
-            <node concept="2C31c$" id="5hdoB45M$gZ" role="2QGGmO">
+            <node concept="2C31c$" id="7tyS2pKEyKk" role="2QGGmO">
               <ref role="2C31c_" node="5W_1Y9DMIW8" resolve="NavFav" />
             </node>
-            <node concept="2C31c$" id="5hdoB45M$h0" role="2QGGmO">
+            <node concept="2C31c$" id="7tyS2pKEyKl" role="2QGGmO">
               <ref role="2C31c_" node="5W_1Y9DMIRk" resolve="GW" />
             </node>
           </node>
@@ -2094,21 +2094,27 @@
         <property role="133MFP" value="" />
         <node concept="2Q16Lc" id="501$dK$S_TJ" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTL2u" resolve="TS.1" />
-          <node concept="pcNHv" id="5hdoB45M_cN" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKEyLo" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="3SMGvtS6WNL" resolve="R.1" />
             <ref role="2Dj$GC" node="60wEthBTL2u" resolve="TS.1" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$S_TL" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTL2A" resolve="TS.2" />
-          <node concept="pcNHv" id="5hdoB45M_cV" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKEyLw" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="3SMGvtS6WNg" resolve="R.2" />
             <ref role="2Dj$GC" node="60wEthBTL2A" resolve="TS.2" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$S_TN" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTL2I" resolve="TS.3" />
-          <node concept="pcNHv" id="5hdoB45M_d3" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKEyLC" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="3SMGvtS6WLj" resolve="R.3" />
             <ref role="2Dj$GC" node="60wEthBTL2I" resolve="TS.3" />
           </node>

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -52,6 +52,10 @@
       <concept id="1920997147008949188" name="com.moraad.suggestions.structure.RiskAssistantSelector" flags="ng" index="CEhHY" />
       <concept id="1920997147009089272" name="com.moraad.suggestions.structure.AssRiskSuggestionFactory" flags="ng" index="CENT2" />
       <concept id="8675225129845988701" name="com.moraad.suggestions.structure.AssDsThreatenedByTsSuggestionFactory" flags="ng" index="2FpSCn" />
+      <concept id="4155569431961189920" name="com.moraad.suggestions.structure.InteractionAssistantSelector" flags="ng" index="2IbN91" />
+      <concept id="4155569431961199169" name="com.moraad.suggestions.structure.AssInteractionSuggestionFactory" flags="ng" index="2IbQSw">
+        <reference id="4155569431963318236" name="context" index="2I3FIX" />
+      </concept>
       <concept id="1069594670716434985" name="com.moraad.suggestions.structure.AssConceptUpdateSuggestionFactory" flags="ng" index="2JoWM6" />
       <concept id="1069594670716328269" name="com.moraad.suggestions.structure.ConceptUpdateAssistantSelector" flags="ng" index="2JpmZy" />
       <concept id="1715757343547858166" name="com.moraad.suggestions.structure.ClaimCreationAssistantSelector" flags="ng" index="2LfSj0" />
@@ -3061,6 +3065,265 @@
                 <ref role="122Z_O" to="72tq:2kMEKexN6m" resolve="Private Secured" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2Q15JU" id="7tyS2pKL1Fq">
+    <property role="3GE5qa" value="Security Analysis.Assistants" />
+    <node concept="2IbN91" id="7tyS2pKL1Fp" role="kmFqQ" />
+    <node concept="2IbQSw" id="7tyS2pKL1Fs" role="2Q$E0J">
+      <ref role="2I3FIX" node="7UMEm_O2H$g" resolve="DrvCAN" />
+      <node concept="3aHhih" id="7tyS2pKL1Fu" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Fx" role="3aHmvd">
+          <ref role="2ClQv0" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          <node concept="k5JqA" id="7tyS2pKL1Fy" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FA" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1F$" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1F_" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Fz" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FB" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$g" resolve="DrvCAN" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1Fv" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1FJ" role="3aHmvd">
+          <ref role="2ClQv0" node="5W_1Y9DMIRk" resolve="GW" />
+          <node concept="k5JqA" id="7tyS2pKL1FN" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1FL" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:2Wj3TpYBON8" resolve="TC.4b" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+            <node concept="3$cmbp" id="7tyS2pKL1FM" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTL2A" resolve="TS.2" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FK" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FO" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1Fw" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1FV" role="3aHmvd">
+          <ref role="2ClQv0" node="5W_1Y9DMITd" resolve="ESP" />
+          <node concept="k5JqA" id="7tyS2pKL1FY" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="5W_1Y9DMITd" resolve="ESP" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FX" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="5W_1Y9DMITd" resolve="ESP" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FW" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="5W_1Y9DMITd" resolve="ESP" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1FZ" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="5W_1Y9DMITd" resolve="ESP" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1Fr" role="2Q$E0J">
+      <ref role="2I3FIX" node="7UMEm_NKmKz" resolve="WL" />
+      <node concept="3aHhih" id="7tyS2pKL1GG" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1GJ" role="3aHmvd">
+          <ref role="2ClQv0" node="7UMEm_NKmKz" resolve="WL" />
+          <node concept="k5JqA" id="7tyS2pKL1GK" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="7UMEm_NKmKz" resolve="WL" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1GR" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="7UMEm_NKmKz" resolve="WL" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1GP" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="7UMEm_NKmKz" resolve="WL" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1GQ" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="7UMEm_NKmKz" resolve="WL" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1GL" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="7UMEm_NKmKz" resolve="WL" />
+            <node concept="3$cmbp" id="7tyS2pKL1GM" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTL2I" resolve="TS.3" />
+            </node>
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1GN" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQto" resolve="TC.6a" />
+            <ref role="2Dj$GC" node="7UMEm_NKmKz" resolve="WL" />
+            <node concept="3$cmbp" id="7tyS2pKL1GO" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTL2u" resolve="TS.1" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1GH" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1H1" role="3aHmvd">
+          <ref role="2ClQv0" node="5W_1Y9DMIQH" resolve="BE" />
+          <node concept="k5JqA" id="7tyS2pKL1H4" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIQH" resolve="BE" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1H3" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIQH" resolve="BE" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1H2" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIQH" resolve="BE" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1H5" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIQH" resolve="BE" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1GI" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Hb" role="3aHmvd">
+          <ref role="2ClQv0" node="5W_1Y9DMIRk" resolve="GW" />
+          <node concept="k5JqA" id="7tyS2pKL1Hf" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1Hd" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:2Wj3TpYBON8" resolve="TC.4b" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+            <node concept="3$cmbp" id="7tyS2pKL1He" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTL2A" resolve="TS.2" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Hc" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Hg" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1Ft" role="2Q$E0J">
+      <ref role="2I3FIX" node="7UMEm_O2H$p" resolve="MediaCAN" />
+      <node concept="3aHhih" id="7tyS2pKL1G5" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1G8" role="3aHmvd">
+          <ref role="2ClQv0" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          <node concept="k5JqA" id="7tyS2pKL1G9" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQli" resolve="TC.1" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Gd" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Gb" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpf" resolve="TC.3" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Gc" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Ga" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Ge" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="7UMEm_O2H$p" resolve="MediaCAN" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1G6" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Gm" role="3aHmvd">
+          <ref role="2ClQv0" node="5W_1Y9DMIRk" resolve="GW" />
+          <node concept="k5JqA" id="7tyS2pKL1Gq" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1Go" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:2Wj3TpYBON8" resolve="TC.4b" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+            <node concept="3$cmbp" id="7tyS2pKL1Gp" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTL2A" resolve="TS.2" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Gn" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Gr" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIRk" resolve="GW" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1G7" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1Gy" role="3aHmvd">
+          <ref role="2ClQv0" node="5W_1Y9DMIS8" resolve="Nav" />
+          <node concept="k5JqA" id="7tyS2pKL1G_" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQmG" resolve="TC.2" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIS8" resolve="Nav" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1G$" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQpp" resolve="TC.4" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIS8" resolve="Nav" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1Gz" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQqK" resolve="TC.5" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIS8" resolve="Nav" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1GA" role="2QGid4">
+            <ref role="2ClRH1" to="7el1:4CQftq3lQsu" resolve="TC.6" />
+            <ref role="2Dj$GC" node="5W_1Y9DMIS8" resolve="Nav" />
           </node>
         </node>
       </node>

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -268,7 +268,7 @@
       </concept>
       <concept id="6495719316977867921" name="com.moraad.core.structure.ConceptElement" flags="ng" index="3bfFbs">
         <child id="6495719316977867929" name="requirements" index="3bfFbk" />
-        <child id="6495719316977867928" name="risk" index="3bfFbl" />
+        <child id="6495719316977867928" name="risks" index="3bfFbl" />
       </concept>
       <concept id="709149415121875681" name="com.moraad.core.structure.DamageCriteriaForClassAssignments" flags="ng" index="3cP9l3">
         <child id="709149415121878132" name="damageCriteriaAssignments" index="3cP9Jm" />

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -2354,7 +2354,7 @@
         <node concept="3VMn$a" id="5F0rLLZnk2e" role="3GS99T" />
       </node>
       <node concept="3GSqTS" id="1PEmpgFmaYK" role="2H0S5D">
-        <property role="TrG5h" value="18" />
+        <property role="TrG5h" value="18 Devices connected to external interfaces e.g. USB ports, OBD port, used as a means to attack vehicle systems" />
       </node>
       <node concept="2H0S4X" id="1PEmpgFmaYL" role="2H0S5D">
         <property role="TrG5h" value="External interfaces such as USB or other ports used as a point of attack, for example through code injection" />

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -368,6 +368,9 @@
       <concept id="7050052209593327468" name="com.moraad.components.structure.TOEChannelContentSelector" flags="ng" index="2x4$Td" />
       <concept id="5188113475688114801" name="com.moraad.components.structure.FunctionAssignmentChunk" flags="ng" index="2zckJ6">
         <property id="8675533035648326051" name="showSmartViewByDefault" index="32ArrR" />
+        <child id="2903910728803987" name="functions" index="1Bunu4" />
+        <child id="2903910728803983" name="smartFunctionAssignables" index="1Bunuo" />
+        <child id="2903910728803980" name="functionAssignables" index="1Bunur" />
         <child id="2094790996039355713" name="smartFuncAssignments" index="3KzJKe" />
       </concept>
       <concept id="5188113475686638955" name="com.moraad.components.structure.TOEData" flags="ng" index="2zhWjs" />
@@ -379,6 +382,7 @@
       <concept id="1210691741201230377" name="com.moraad.components.structure.IFunctionAssignable" flags="ng" index="1e0lug">
         <child id="6569433384300427095" name="assignedFunctions" index="lYIuc" />
       </concept>
+      <concept id="3043868224835494635" name="com.moraad.components.structure.TOEChannelRef" flags="ng" index="3mlHNI" />
       <concept id="3043868224835494634" name="com.moraad.components.structure.TOEChannel" flags="ng" index="3mlHNJ">
         <child id="6453420821188241049" name="endPoints" index="38xWUi" />
         <child id="7233123248602290786" name="dataFlows" index="3XVyOB" />
@@ -387,6 +391,10 @@
         <reference id="4250072277178649488" name="target" index="3$0O6B" />
       </concept>
       <concept id="4250072277178649596" name="com.moraad.components.structure.TOEComponentRef" flags="ng" index="3$0O7b" />
+      <concept id="2903910728542993" name="com.moraad.components.structure.SmartFunctionAssignable" flags="ng" index="1BpnC6">
+        <reference id="2903910728542996" name="origin" index="1BpnC3" />
+        <child id="2903910728542994" name="data" index="1BpnC5" />
+      </concept>
       <concept id="9034427618896218585" name="com.moraad.components.structure.TOEDataFlowRef" flags="ng" index="3Kajnk" />
       <concept id="9034427618896207423" name="com.moraad.components.structure.TOEDataFlow" flags="ng" index="3Kau8M">
         <reference id="549470471296403036" name="targetRef" index="27$5CB" />
@@ -1273,6 +1281,36 @@
   <node concept="2zckJ6" id="5W_1Y9DMGvH">
     <property role="3GE5qa" value="Item Definition" />
     <property role="32ArrR" value="true" />
+    <node concept="1BpnC6" id="1V484Ri7HKC" role="1Bunuo">
+      <ref role="1BpnC3" node="5W_1Y9DMIRk" resolve="GW" />
+      <node concept="3KzYab" id="1V484Ri7HKB" role="1BpnC5">
+        <ref role="122Z_O" node="2Bvf77vYioF" resolve="AESKey" />
+      </node>
+    </node>
+    <node concept="3KzYab" id="1V484Ri7HKt" role="1Bunur">
+      <ref role="122Z_O" node="2Bvf77vYioF" resolve="AESKey" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7HKr" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMIVI" resolve="ESP-FW" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7HKs" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMIW8" resolve="NavFav" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7HKq" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMIQH" resolve="BE" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7HKp" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMITd" resolve="ESP" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7HKn" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMIRk" resolve="GW" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7HKo" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMIS8" resolve="Nav" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7HKl" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMGvw" resolve="SYS" />
+    </node>
     <node concept="3KzJKc" id="6oAaSFUtiK" role="3KzJKe">
       <ref role="3KzJK7" node="5W_1Y9DMIVI" resolve="ESP-FW" />
       <ref role="3KDv1v" node="5W_1Y9DMIPU" resolve="OTA-Update" />
@@ -1307,6 +1345,75 @@
       <ref role="3KzJK7" node="5W_1Y9DMIW8" resolve="NavFav" />
       <ref role="3KzJK9" node="5W_1Y9DMIS8" resolve="Nav" />
       <ref role="3KDv1v" node="5W_1Y9DMIPZ" resolve="Sync-NavDst" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7HKm" role="1Bunur">
+      <ref role="122Z_O" node="5W_1Y9DMIQd" resolve="VHC" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7HKv" role="1Bunur">
+      <ref role="122Z_O" node="7UMEm_O2H$g" resolve="DrvCAN" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7HKw" role="1Bunur">
+      <ref role="122Z_O" node="7UMEm_O2H$p" resolve="MediaCAN" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7HKu" role="1Bunur">
+      <ref role="122Z_O" node="7UMEm_NKmKz" resolve="WL" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7HKi" role="1Bunur">
+      <ref role="122Z_O" node="3KbYnAvU9Dp" resolve="Ch.1" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7HKj" role="1Bunur">
+      <ref role="122Z_O" node="3KbYnAvU9Dv" resolve="Ch.2" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7HKk" role="1Bunur">
+      <ref role="122Z_O" node="3KbYnAvU9D_" resolve="Ch.3" />
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HKy" role="1Bunuo">
+      <ref role="1BpnC3" node="5W_1Y9DMIQH" resolve="BE" />
+      <node concept="3KzYab" id="1V484Ri7HKx" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIVI" resolve="ESP-FW" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HKA" role="1Bunuo">
+      <ref role="1BpnC3" node="5W_1Y9DMIQH" resolve="BE" />
+      <node concept="3KzYab" id="1V484Ri7HK_" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIW8" resolve="NavFav" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HK$" role="1Bunuo">
+      <ref role="1BpnC3" node="5W_1Y9DMIS8" resolve="Nav" />
+      <node concept="3KzYab" id="1V484Ri7HKz" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIW8" resolve="NavFav" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HKG" role="1Bunuo">
+      <ref role="1BpnC3" node="7UMEm_O2H$g" resolve="DrvCAN" />
+      <node concept="3KzYab" id="1V484Ri7HKF" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIVI" resolve="ESP-FW" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HKE" role="1Bunuo">
+      <ref role="1BpnC3" node="7UMEm_NKmKz" resolve="WL" />
+      <node concept="3KzYab" id="1V484Ri7HKD" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIVI" resolve="ESP-FW" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HKK" role="1Bunuo">
+      <ref role="1BpnC3" node="7UMEm_O2H$p" resolve="MediaCAN" />
+      <node concept="3KzYab" id="1V484Ri7HKJ" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIW8" resolve="NavFav" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7HKI" role="1Bunuo">
+      <ref role="1BpnC3" node="7UMEm_NKmKz" resolve="WL" />
+      <node concept="3KzYab" id="1V484Ri7HKH" role="1BpnC5">
+        <ref role="122Z_O" node="5W_1Y9DMIW8" resolve="NavFav" />
+      </node>
+    </node>
+    <node concept="IT3p4" id="1V484Ri7HKL" role="1Bunu4">
+      <ref role="122Z_O" node="5W_1Y9DMIPU" resolve="OTA-Update" />
+    </node>
+    <node concept="IT3p4" id="1V484Ri7HKM" role="1Bunu4">
+      <ref role="122Z_O" node="5W_1Y9DMIPZ" resolve="Sync-NavDst" />
     </node>
   </node>
   <node concept="2Q15JU" id="3ND63w_kVnf">

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -11,6 +11,7 @@
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
       <concept id="8278271381845378605" name="de.itemis.ysec.methodConfiguration.structure.AFLRef" flags="ng" index="1vNPnr" />
+      <concept id="8849129041839306048" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelRef" flags="ng" index="3GCHUU" />
       <concept id="6006699537885391512" name="de.itemis.ysec.methodConfiguration.structure.SecurityGoalClassRef" flags="ng" index="3RtnZZ" />
     </language>
     <language id="77390b0e-ab69-4de7-a036-d557f81b479e" name="de.itemis.ysec.catalog.technologies">
@@ -337,11 +338,19 @@
     <language id="c1497963-7ffd-4da0-9a4d-74675c5ab7e2" name="com.moraad.components">
       <concept id="4903305818773966639" name="com.moraad.components.structure.TOEChunk" flags="ng" index="2lbcm6" />
       <concept id="4903305818773971546" name="com.moraad.components.structure.TOEComponent" flags="ng" index="2lbezN">
+        <child id="7296163292644697544" name="trustZone" index="345swj" />
         <child id="1808727333797819112" name="subComponents" index="1b_L45" />
         <child id="1808727333797819114" name="storedData" index="1b_L47" />
       </concept>
       <concept id="4903305818773998197" name="com.moraad.components.structure.ITOEElementContainer" flags="ng" index="2lbk3s">
         <child id="4903305818773998200" name="elements" index="2lbk3h" />
+      </concept>
+      <concept id="5693834772128144381" name="com.moraad.components.structure.TrustZoneChunk" flags="ng" index="2lsSHN">
+        <child id="5693834772129560276" name="trustZones" index="2ly2pq" />
+      </concept>
+      <concept id="5693834772129554889" name="com.moraad.components.structure.TrustZone" flags="ng" index="2ly357">
+        <child id="5693834772130897929" name="subZones" index="2lDr27" />
+        <child id="8849129041839306097" name="trustLevel" index="3GCHUb" />
       </concept>
       <concept id="3911760519739995188" name="com.moraad.components.structure.SystemDiagram" flags="ng" index="2ndE_3">
         <property id="1514418932059619330" name="hierarchyLevels" index="2zzwJW" />
@@ -360,6 +369,8 @@
       <concept id="5188113475686638955" name="com.moraad.components.structure.TOEData" flags="ng" index="2zhWjs" />
       <concept id="2560071392251274778" name="com.moraad.components.structure.TOEFunction" flags="ng" index="Hgtl4" />
       <concept id="8237891392911108311" name="com.moraad.components.structure.TOEFunctionRef" flags="ng" index="IT3p4" />
+      <concept id="812298049876156433" name="com.moraad.components.structure.TrustZoneContentSelector" flags="ng" index="31QrNk" />
+      <concept id="7296163292644697473" name="com.moraad.components.structure.TrustZoneRef" flags="ng" index="345sxq" />
       <concept id="8675533035673365864" name="com.moraad.components.structure.FunctionAssignment" flags="ng" index="347S8W" />
       <concept id="1210691741201230377" name="com.moraad.components.structure.IFunctionAssignable" flags="ng" index="1e0lug">
         <child id="6569433384300427095" name="assignedFunctions" index="lYIuc" />
@@ -740,6 +751,9 @@
           <node concept="347S8W" id="5hdoB45MD0E" role="lYIuc">
             <ref role="122Z_O" node="5W_1Y9DMIPU" resolve="OTA-Update" />
           </node>
+          <node concept="345sxq" id="59GJRmKRhRf" role="345swj">
+            <ref role="122Z_O" node="59GJRmKEMJo" resolve="TZ.5" />
+          </node>
         </node>
         <node concept="3VMn$a" id="4O7c2ukunKK" role="2JHqPs" />
         <node concept="347S8W" id="5hdoB45MD0O" role="lYIuc">
@@ -747,6 +761,9 @@
         </node>
         <node concept="347S8W" id="5hdoB45MD0S" role="lYIuc">
           <ref role="122Z_O" node="5W_1Y9DMIPZ" resolve="Sync-NavDst" />
+        </node>
+        <node concept="345sxq" id="59GJRmKRhRh" role="345swj">
+          <ref role="122Z_O" node="59GJRmKEMJk" resolve="TZ.4" />
         </node>
       </node>
       <node concept="2lbezN" id="5W_1Y9DMIQH" role="1b_L45">
@@ -764,6 +781,9 @@
         </node>
         <node concept="347S8W" id="5hdoB45MD0R" role="lYIuc">
           <ref role="122Z_O" node="5W_1Y9DMIPZ" resolve="Sync-NavDst" />
+        </node>
+        <node concept="345sxq" id="59GJRmKRhRj" role="345swj">
+          <ref role="122Z_O" node="59GJRmKEMJg" resolve="TZ.3" />
         </node>
       </node>
       <node concept="3VMn$a" id="4O7c2ukunCn" role="2JHqPs">
@@ -3000,6 +3020,51 @@
       </node>
     </node>
     <node concept="2j6TKA" id="1xzt3hRBmrp" role="2jedq2" />
+  </node>
+  <node concept="2lsSHN" id="7tyS2pKKZNn">
+    <property role="3GE5qa" value="Item Definition" />
+    <property role="TrG5h" value="Trust Zones" />
+    <node concept="31QrNk" id="7tyS2pKKZNo" role="2xH1$J" />
+    <node concept="2ly357" id="59GJRmKEMJ8" role="2ly2pq">
+      <property role="DVXpC" value="Internet" />
+      <property role="TrG5h" value="TZ.1" />
+      <node concept="3VMn$a" id="59GJRmKEMJ9" role="2JHqPs" />
+      <node concept="3GCHUU" id="59GJRmKEMJb" role="3GCHUb">
+        <ref role="122Z_O" to="72tq:2kMEKexN5U" resolve="Internet" />
+      </node>
+      <node concept="2ly357" id="59GJRmKEMJc" role="2lDr27">
+        <property role="DVXpC" value="Public" />
+        <property role="TrG5h" value="TZ.2" />
+        <node concept="3VMn$a" id="59GJRmKEMJd" role="2JHqPs" />
+        <node concept="3GCHUU" id="59GJRmKEMJf" role="3GCHUb">
+          <ref role="122Z_O" to="72tq:2kMEKexN5Y" resolve="Public" />
+        </node>
+        <node concept="2ly357" id="59GJRmKEMJg" role="2lDr27">
+          <property role="DVXpC" value="Public Cloud" />
+          <property role="TrG5h" value="TZ.3" />
+          <node concept="3VMn$a" id="59GJRmKEMJh" role="2JHqPs" />
+          <node concept="3GCHUU" id="59GJRmKEMJj" role="3GCHUb">
+            <ref role="122Z_O" to="72tq:2kMEKexN64" resolve="Public Cloud" />
+          </node>
+          <node concept="2ly357" id="59GJRmKEMJk" role="2lDr27">
+            <property role="DVXpC" value="Trusted Partner" />
+            <property role="TrG5h" value="TZ.4" />
+            <node concept="3VMn$a" id="59GJRmKEMJl" role="2JHqPs" />
+            <node concept="3GCHUU" id="59GJRmKEMJn" role="3GCHUb">
+              <ref role="122Z_O" to="72tq:2kMEKexN6c" resolve="Trusted Partner" />
+            </node>
+            <node concept="2ly357" id="59GJRmKEMJo" role="2lDr27">
+              <property role="DVXpC" value="Private Secured" />
+              <property role="TrG5h" value="TZ.5" />
+              <node concept="3VMn$a" id="59GJRmKEMJp" role="2JHqPs" />
+              <node concept="3GCHUU" id="59GJRmKEMJr" role="3GCHUb">
+                <ref role="122Z_O" to="72tq:2kMEKexN6m" resolve="Private Secured" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -23,7 +23,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -60,7 +60,15 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -69,6 +77,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate1/StandardComposition/models/MethodConfiguration.mps
+++ b/RemoteUpdate1/StandardComposition/models/MethodConfiguration.mps
@@ -9,6 +9,9 @@
   </imports>
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
+      <concept id="8140327204155191530" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelsDefinition" flags="ng" index="fTz2s">
+        <child id="8140327204155191533" name="levels" index="fTz2r" />
+      </concept>
       <concept id="4497791247486336887" name="de.itemis.ysec.methodConfiguration.structure.DamageClass" flags="ng" index="i8Y8S" />
       <concept id="7480212422238926806" name="de.itemis.ysec.methodConfiguration.structure.ImpactScale" flags="ng" index="2nNfD6">
         <property id="7480212422238960135" name="value" index="2nMRun" />
@@ -35,11 +38,24 @@
         <property id="8045787582102992758" name="value" index="uPLpr" />
       </concept>
       <concept id="5265403561757222969" name="de.itemis.ysec.methodConfiguration.structure.Stakeholder" flags="ng" index="CzX2t" />
+      <concept id="848894267652668100" name="de.itemis.ysec.methodConfiguration.structure.TrustLevel" flags="ng" index="2KyDCi">
+        <property id="7152850790341018718" name="value" index="qSweV" />
+      </concept>
       <concept id="227120341090634910" name="de.itemis.ysec.methodConfiguration.structure.AFLsDefinition" flags="ng" index="KRYwx">
         <child id="227120341090909991" name="values" index="KQXIo" />
       </concept>
       <concept id="227120341090635007" name="de.itemis.ysec.methodConfiguration.structure.AttackFeasibilityLevel" flags="ng" index="KRYx0">
         <property id="227120341090910048" name="minimalValue" index="KQXJv" />
+      </concept>
+      <concept id="848894267651765571" name="de.itemis.ysec.methodConfiguration.structure.TrustModel" flags="ng" index="2KY5ml">
+        <child id="8140327204155204736" name="trustLevelsDefinition" index="fTIjQ" />
+        <child id="4520112907071583232" name="trustBoundaryCategoriesDefinition" index="2O4_UX" />
+      </concept>
+      <concept id="4520112907071582378" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategoriesDefinition" flags="ng" index="2O4_Cn">
+        <child id="4520112907071582379" name="categories" index="2O4_Cm" />
+      </concept>
+      <concept id="4520112907071235583" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategory" flags="ng" index="2O6gX2">
+        <property id="4520112907071235800" name="value" index="2O6gL_" />
       </concept>
       <concept id="1756525789544303273" name="de.itemis.ysec.methodConfiguration.structure.DamagePotentialsDefinition" flags="ng" index="OYqhf">
         <child id="1756525789544303274" name="values" index="OYqhc" />
@@ -4041,6 +4057,176 @@
     <property role="TrG5h" value="ISO/SAE 21434 Terminology" />
     <property role="3GE5qa" value="Advanced" />
     <ref role="3iLw6d" to="si5v:3xoDER5IZYq" resolve="ISO/SAE 21434 Terminology (Default)" />
+  </node>
+  <node concept="2KY5ml" id="2kMEKexN5T">
+    <property role="TrG5h" value="Trust Model" />
+    <node concept="fTz2s" id="73Sg7pZ8d6f" role="fTIjQ">
+      <node concept="2KyDCi" id="2kMEKexN5U" role="fTz2r">
+        <property role="TrG5h" value="Internet" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5V" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeo" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNep" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeq" role="3VMn$3">
+              <property role="3VMn$Y" value="Internet" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNer" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNes" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNee" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN5Y" role="fTz2r">
+        <property role="TrG5h" value="Public" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5Z" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNey" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNez" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe$" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe_" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNeg" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN64" role="fTz2r">
+        <property role="TrG5h" value="Public Cloud" />
+        <property role="qSweV" value="60" />
+        <node concept="3VMn$a" id="2kMEKexN65" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeE" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeF" role="3VMn$3">
+              <property role="3VMn$Y" value="Public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeG" role="3VMn$3">
+              <property role="3VMn$Y" value="cloud" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeH" role="3VMn$3">
+              <property role="3VMn$Y" value="service" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNei" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6c" role="fTz2r">
+        <property role="TrG5h" value="Trusted Partner" />
+        <property role="qSweV" value="80" />
+        <node concept="3VMn$a" id="2kMEKexN6d" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeM" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeN" role="3VMn$3">
+              <property role="3VMn$Y" value="Vetted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeO" role="3VMn$3">
+              <property role="3VMn$Y" value="and" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeP" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeQ" role="3VMn$3">
+              <property role="3VMn$Y" value="partner" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNek" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6m" role="fTz2r">
+        <property role="TrG5h" value="Private Secured" />
+        <property role="qSweV" value="100" />
+        <node concept="3VMn$a" id="2kMEKexN6n" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeW" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeX" role="3VMn$3">
+              <property role="3VMn$Y" value="A" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeY" role="3VMn$3">
+              <property role="3VMn$Y" value="secured" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeZ" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf0" role="3VMn$3">
+              <property role="3VMn$Y" value="within" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf1" role="3VMn$3">
+              <property role="3VMn$Y" value="a" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf2" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf3" role="3VMn$3">
+              <property role="3VMn$Y" value="private" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf4" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNem" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+    </node>
+    <node concept="2O4_Cn" id="3UUEFQaLz58" role="2O4_UX">
+      <node concept="2O6gX2" id="3UUEFQaLz5a" role="2O4_Cm">
+        <property role="2O6gL_" value="0" />
+        <node concept="3VMn$a" id="3UUEFQaLz5b" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5e" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5g" role="2O4_Cm">
+        <property role="2O6gL_" value="20" />
+        <node concept="3VMn$a" id="3UUEFQaLz5h" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5s" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5u" role="2O4_Cm">
+        <property role="2O6gL_" value="40" />
+        <node concept="3VMn$a" id="3UUEFQaLz5v" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5C" role="E7tE9">
+          <property role="1iTho6" value="FFFF99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5E" role="2O4_Cm">
+        <property role="2O6gL_" value="60" />
+        <node concept="3VMn$a" id="3UUEFQaLz5F" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5R" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5T" role="2O4_Cm">
+        <property role="2O6gL_" value="80" />
+        <node concept="3VMn$a" id="3UUEFQaLz5U" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz69" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz6b" role="2O4_Cm">
+        <property role="2O6gL_" value="100" />
+        <node concept="3VMn$a" id="3UUEFQaLz6c" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz6u" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -63,8 +63,16 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="9d40c97c-ad78-428c-bfe2-2c091d2c2af8(ExampleAnalysis)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -73,6 +81,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -2934,70 +2934,90 @@
         <property role="133MFP" value="" />
         <node concept="2Q16Lc" id="501$dK$SAi0" role="3aHmvd">
           <ref role="2ClQv0" node="1UEFqBLBoOR" resolve="G.1" />
-          <node concept="pcNHv" id="501$dK$SAi1" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$Oh" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1UEFqBLBtKK" resolve="R.1" />
             <ref role="2Dj$GC" node="1UEFqBLBoOR" resolve="G.1" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAi2" role="3aHmvd">
           <ref role="2ClQv0" node="1UEFqBLBoP4" resolve="G.2" />
-          <node concept="pcNHv" id="501$dK$SAi3" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$OB" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1UEFqBLBtKQ" resolve="R.2" />
             <ref role="2Dj$GC" node="1UEFqBLBoP4" resolve="G.2" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAi4" role="3aHmvd">
           <ref role="2ClQv0" node="1UEFqBLBrNo" resolve="G.3" />
-          <node concept="pcNHv" id="501$dK$SAi5" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$OX" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1UEFqBLBtKZ" resolve="R.3" />
             <ref role="2Dj$GC" node="1UEFqBLBrNo" resolve="G.3" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAi6" role="3aHmvd">
           <ref role="2ClQv0" node="1UEFqBLBrNL" resolve="G.4" />
-          <node concept="pcNHv" id="501$dK$SAi7" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$Pj" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1UEFqBLBtLb" resolve="R.4" />
             <ref role="2Dj$GC" node="1UEFqBLBrNL" resolve="G.4" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAi8" role="3aHmvd">
           <ref role="2ClQv0" node="1UEFqBLBrOg" resolve="G.5" />
-          <node concept="pcNHv" id="501$dK$SAi9" role="2QGid4">
+          <node concept="pcNHv" id="7tyS2pKE$PD" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1UEFqBLBtLs" resolve="R.5" />
             <ref role="2Dj$GC" node="1UEFqBLBrOg" resolve="G.5" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAia" role="3aHmvd">
           <ref role="2ClQv0" node="1UEFqBLBu0A" resolve="G.6" />
-          <node concept="CLQ85" id="501$dK$SAib" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKE$PZ" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="1UEFqBLBu0A" resolve="G.6" />
             <ref role="2Dj$GC" node="1UEFqBLBu0A" resolve="G.6" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAic" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTLex" resolve="TS.7" />
-          <node concept="CLQ85" id="501$dK$SAid" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKE$Ql" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTLex" resolve="TS.7" />
             <ref role="2Dj$GC" node="60wEthBTLex" resolve="TS.7" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAie" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTLeE" resolve="TS.8" />
-          <node concept="CLQ85" id="501$dK$SAif" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKE$QF" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTLeE" resolve="TS.8" />
             <ref role="2Dj$GC" node="60wEthBTLeE" resolve="TS.8" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAig" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTLeN" resolve="TS.9" />
-          <node concept="CLQ85" id="501$dK$SAih" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKE$R1" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTLeN" resolve="TS.9" />
             <ref role="2Dj$GC" node="60wEthBTLeN" resolve="TS.9" />
           </node>
         </node>
         <node concept="2Q16Lc" id="501$dK$SAii" role="3aHmvd">
           <ref role="2ClQv0" node="60wEthBTLeW" resolve="TS.10" />
-          <node concept="CLQ85" id="501$dK$SAij" role="2QGid4">
+          <node concept="CLQ85" id="7tyS2pKE$Rn" role="2QGid4">
+            <property role="2yT22K" value="null ()" />
+            <property role="2yT22M" value="null ()" />
             <ref role="2ClRH1" node="60wEthBTLeW" resolve="TS.10" />
             <ref role="2Dj$GC" node="60wEthBTLeW" resolve="TS.10" />
           </node>

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -372,19 +372,26 @@
       <concept id="7050052209593327464" name="com.moraad.components.structure.TOEDataContentSelector" flags="ng" index="2x4$T9" />
       <concept id="7050052209593327466" name="com.moraad.components.structure.TOEComponentContentSelector" flags="ng" index="2x4$Tb" />
       <concept id="7050052209593327468" name="com.moraad.components.structure.TOEChannelContentSelector" flags="ng" index="2x4$Td" />
-      <concept id="5188113475688114801" name="com.moraad.components.structure.FunctionAssignmentChunk" flags="ng" index="2zckJ6" />
+      <concept id="5188113475688114801" name="com.moraad.components.structure.FunctionAssignmentChunk" flags="ng" index="2zckJ6">
+        <property id="8675533035648326051" name="showSmartViewByDefault" index="32ArrR" />
+        <child id="2903910728803987" name="functions" index="1Bunu4" />
+        <child id="2903910728803983" name="smartFunctionAssignables" index="1Bunuo" />
+        <child id="2903910728803980" name="functionAssignables" index="1Bunur" />
+      </concept>
       <concept id="5188113475686638955" name="com.moraad.components.structure.TOEData" flags="ng" index="2zhWjs">
         <child id="1808727333803133825" name="subData" index="1bYuxG" />
       </concept>
       <concept id="2560071392251274778" name="com.moraad.components.structure.TOEFunction" flags="ng" index="Hgtl4">
         <child id="2560071392251424218" name="subFunctions" index="HjxU4" />
       </concept>
+      <concept id="8237891392911108311" name="com.moraad.components.structure.TOEFunctionRef" flags="ng" index="IT3p4" />
       <concept id="812298049876156433" name="com.moraad.components.structure.TrustZoneContentSelector" flags="ng" index="31QrNk" />
       <concept id="7296163292644697473" name="com.moraad.components.structure.TrustZoneRef" flags="ng" index="345sxq" />
       <concept id="8675533035673365864" name="com.moraad.components.structure.FunctionAssignment" flags="ng" index="347S8W" />
       <concept id="1210691741201230377" name="com.moraad.components.structure.IFunctionAssignable" flags="ng" index="1e0lug">
         <child id="6569433384300427095" name="assignedFunctions" index="lYIuc" />
       </concept>
+      <concept id="3043868224835494635" name="com.moraad.components.structure.TOEChannelRef" flags="ng" index="3mlHNI" />
       <concept id="3043868224835494634" name="com.moraad.components.structure.TOEChannel" flags="ng" index="3mlHNJ">
         <child id="6453420821188241049" name="endPoints" index="38xWUi" />
         <child id="7233123248602290786" name="dataFlows" index="3XVyOB" />
@@ -393,6 +400,10 @@
         <reference id="4250072277178649488" name="target" index="3$0O6B" />
       </concept>
       <concept id="4250072277178649596" name="com.moraad.components.structure.TOEComponentRef" flags="ng" index="3$0O7b" />
+      <concept id="2903910728542993" name="com.moraad.components.structure.SmartFunctionAssignable" flags="ng" index="1BpnC6">
+        <reference id="2903910728542996" name="origin" index="1BpnC3" />
+        <child id="2903910728542994" name="data" index="1BpnC5" />
+      </concept>
       <concept id="9034427618896218585" name="com.moraad.components.structure.TOEDataFlowRef" flags="ng" index="3Kajnk" />
       <concept id="9034427618896207423" name="com.moraad.components.structure.TOEDataFlow" flags="ng" index="3Kau8M">
         <reference id="549470471296403036" name="targetRef" index="27$5CB" />
@@ -1735,6 +1746,115 @@
   </node>
   <node concept="2zckJ6" id="1E_VH$V8tTF">
     <property role="3GE5qa" value="Item Definition" />
+    <property role="32ArrR" value="true" />
+    <node concept="IT3p4" id="1V484Ri7Ijb" role="1Bunu4">
+      <ref role="122Z_O" node="1E_VH$V8uhb" resolve="DL SW-Update" />
+    </node>
+    <node concept="IT3p4" id="1V484Ri7Ija" role="1Bunu4">
+      <ref role="122Z_O" node="1E_VH$V8uh3" resolve="DL User Data" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7IiP" role="1Bunur">
+      <ref role="122Z_O" node="1UEFqBLBtUe" resolve="AES key" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7IiL" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u3f" resolve="REQ" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7IiM" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u63" resolve="RES" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7IiO" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u6n" resolve="SW Update" />
+    </node>
+    <node concept="3KzYab" id="1V484Ri7IiN" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u6b" resolve="Weather data" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7IiI" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u3k" resolve="ConECU" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7IiH" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u1H" resolve="HU" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7IiF" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8tTu" resolve="SYS" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7IiK" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u19" resolve="Server" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7IiJ" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u4q" resolve="Steering" />
+    </node>
+    <node concept="3$0O7b" id="1V484Ri7IiG" role="1Bunur">
+      <ref role="122Z_O" node="1E_VH$V8u0P" resolve="VEH" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7IiQ" role="1Bunur">
+      <ref role="122Z_O" node="3who49CIQPO" resolve="DF.1" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7IiS" role="1Bunur">
+      <ref role="122Z_O" node="3who49D6lsT" resolve="DF.2" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7IiT" role="1Bunur">
+      <ref role="122Z_O" node="3who49D6lt2" resolve="DF.3" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7IiR" role="1Bunur">
+      <ref role="122Z_O" node="3who49D6ltb" resolve="DF.4" />
+    </node>
+    <node concept="3Kajnk" id="1V484Ri7IiU" role="1Bunur">
+      <ref role="122Z_O" node="3who49D6ltk" resolve="DF.5" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7IiC" role="1Bunur">
+      <ref role="122Z_O" node="3KbYnAvUcFY" resolve="Ch.1" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7IiD" role="1Bunur">
+      <ref role="122Z_O" node="3KbYnAvUcG4" resolve="Ch.2" />
+    </node>
+    <node concept="3mlHNI" id="1V484Ri7IiE" role="1Bunur">
+      <ref role="122Z_O" node="3KbYnAvUcGc" resolve="Ch.3" />
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7IiW" role="1Bunuo">
+      <ref role="1BpnC3" node="1E_VH$V8u3k" resolve="ConECU" />
+      <node concept="3KzYab" id="1V484Ri7IiV" role="1BpnC5">
+        <ref role="122Z_O" node="1UEFqBLBtUe" resolve="AES key" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7IiY" role="1Bunuo">
+      <ref role="1BpnC3" node="1E_VH$V8u19" resolve="Server" />
+      <node concept="3KzYab" id="1V484Ri7IiX" role="1BpnC5">
+        <ref role="122Z_O" node="1UEFqBLBtUe" resolve="AES key" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7Ij0" role="1Bunuo">
+      <ref role="1BpnC3" node="3who49CIQPO" resolve="DF.1" />
+      <node concept="3KzYab" id="1V484Ri7IiZ" role="1BpnC5">
+        <ref role="122Z_O" node="1E_VH$V8u3f" resolve="REQ" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7Ij2" role="1Bunuo">
+      <ref role="1BpnC3" node="3who49D6lsT" resolve="DF.2" />
+      <node concept="3KzYab" id="1V484Ri7Ij1" role="1BpnC5">
+        <ref role="122Z_O" node="1E_VH$V8u3f" resolve="REQ" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7Ij4" role="1Bunuo">
+      <ref role="1BpnC3" node="3who49D6lt2" resolve="DF.3" />
+      <node concept="3KzYab" id="1V484Ri7Ij3" role="1BpnC5">
+        <ref role="122Z_O" node="1E_VH$V8u63" resolve="RES" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7Ij8" role="1Bunuo">
+      <ref role="1BpnC3" node="3who49D6ltk" resolve="DF.5" />
+      <node concept="3KzYab" id="1V484Ri7Ij7" role="1BpnC5">
+        <ref role="122Z_O" node="1E_VH$V8u6n" resolve="SW Update" />
+      </node>
+    </node>
+    <node concept="1BpnC6" id="1V484Ri7Ij6" role="1Bunuo">
+      <ref role="1BpnC3" node="3who49D6ltb" resolve="DF.4" />
+      <node concept="3KzYab" id="1V484Ri7Ij5" role="1BpnC5">
+        <ref role="122Z_O" node="1E_VH$V8u6b" resolve="Weather data" />
+      </node>
+    </node>
+    <node concept="IT3p4" id="1V484Ri7Ij9" role="1Bunu4">
+      <ref role="122Z_O" node="1E_VH$V8ugN" resolve="DL" />
+    </node>
   </node>
   <node concept="1mQ_Fh" id="1E_VH$V8tTK">
     <property role="TrG5h" value="RiskTreatment" />

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -10,6 +10,7 @@
   </imports>
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
+      <concept id="8849129041839306048" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelRef" flags="ng" index="3GCHUU" />
       <concept id="6006699537885391512" name="de.itemis.ysec.methodConfiguration.structure.SecurityGoalClassRef" flags="ng" index="3RtnZZ" />
     </language>
     <language id="77390b0e-ab69-4de7-a036-d557f81b479e" name="de.itemis.ysec.catalog.technologies">
@@ -343,11 +344,19 @@
     <language id="c1497963-7ffd-4da0-9a4d-74675c5ab7e2" name="com.moraad.components">
       <concept id="4903305818773966639" name="com.moraad.components.structure.TOEChunk" flags="ng" index="2lbcm6" />
       <concept id="4903305818773971546" name="com.moraad.components.structure.TOEComponent" flags="ng" index="2lbezN">
+        <child id="7296163292644697544" name="trustZone" index="345swj" />
         <child id="1808727333797819112" name="subComponents" index="1b_L45" />
         <child id="1808727333797819114" name="storedData" index="1b_L47" />
       </concept>
       <concept id="4903305818773998197" name="com.moraad.components.structure.ITOEElementContainer" flags="ng" index="2lbk3s">
         <child id="4903305818773998200" name="elements" index="2lbk3h" />
+      </concept>
+      <concept id="5693834772128144381" name="com.moraad.components.structure.TrustZoneChunk" flags="ng" index="2lsSHN">
+        <child id="5693834772129560276" name="trustZones" index="2ly2pq" />
+      </concept>
+      <concept id="5693834772129554889" name="com.moraad.components.structure.TrustZone" flags="ng" index="2ly357">
+        <child id="5693834772130897929" name="subZones" index="2lDr27" />
+        <child id="8849129041839306097" name="trustLevel" index="3GCHUb" />
       </concept>
       <concept id="3911760519739995188" name="com.moraad.components.structure.SystemDiagram" flags="ng" index="2ndE_3">
         <property id="1514418932059619330" name="hierarchyLevels" index="2zzwJW" />
@@ -366,6 +375,8 @@
       <concept id="2560071392251274778" name="com.moraad.components.structure.TOEFunction" flags="ng" index="Hgtl4">
         <child id="2560071392251424218" name="subFunctions" index="HjxU4" />
       </concept>
+      <concept id="812298049876156433" name="com.moraad.components.structure.TrustZoneContentSelector" flags="ng" index="31QrNk" />
+      <concept id="7296163292644697473" name="com.moraad.components.structure.TrustZoneRef" flags="ng" index="345sxq" />
       <concept id="8675533035673365864" name="com.moraad.components.structure.FunctionAssignment" flags="ng" index="347S8W" />
       <concept id="1210691741201230377" name="com.moraad.components.structure.IFunctionAssignable" flags="ng" index="1e0lug">
         <child id="6569433384300427095" name="assignedFunctions" index="lYIuc" />
@@ -1003,6 +1014,9 @@
             <ref role="122Z_O" node="1E_VH$V8uh3" resolve="DL User Data" />
           </node>
           <node concept="3VMn$a" id="4O7c2ukuws1" role="2JHqPs" />
+          <node concept="345sxq" id="59GJRmKRhRp" role="345swj">
+            <ref role="122Z_O" node="59GJRmKEMKu" resolve="TZ.5" />
+          </node>
         </node>
         <node concept="2lbezN" id="1E_VH$V8u3k" role="1b_L45">
           <property role="TrG5h" value="ConECU" />
@@ -1033,6 +1047,9 @@
           <ref role="122Z_O" node="1E_VH$V8uhb" resolve="DL SW-Update" />
         </node>
         <node concept="3VMn$a" id="4O7c2ukuws0" role="2JHqPs" />
+        <node concept="345sxq" id="59GJRmKRhRn" role="345swj">
+          <ref role="122Z_O" node="59GJRmKEMKq" resolve="TZ.4" />
+        </node>
       </node>
       <node concept="2lbezN" id="1E_VH$V8u19" role="1b_L45">
         <property role="TrG5h" value="Server" />
@@ -1047,6 +1064,9 @@
           <ref role="122Z_O" node="1E_VH$V8uhb" resolve="DL SW-Update" />
         </node>
         <node concept="3VMn$a" id="4O7c2ukuws4" role="2JHqPs" />
+        <node concept="345sxq" id="59GJRmKRhRl" role="345swj">
+          <ref role="122Z_O" node="59GJRmKEMKm" resolve="TZ.3" />
+        </node>
       </node>
       <node concept="3VMn$a" id="4O7c2ukuwjl" role="2JHqPs">
         <node concept="3VMn$0" id="4O7c2ukuwjm" role="3VMn$6">
@@ -3920,6 +3940,51 @@
     </node>
     <node concept="2j6TKA" id="1xzt3hRBw2c" role="2jedq2" />
     <node concept="3dGa_S" id="1xzt3hRBw2d" role="2xH1$J" />
+  </node>
+  <node concept="2lsSHN" id="7tyS2pKKZNn">
+    <property role="3GE5qa" value="Item Definition" />
+    <property role="TrG5h" value="Trust Zones" />
+    <node concept="31QrNk" id="7tyS2pKKZNo" role="2xH1$J" />
+    <node concept="2ly357" id="59GJRmKEMKe" role="2ly2pq">
+      <property role="DVXpC" value="Internet" />
+      <property role="TrG5h" value="TZ.1" />
+      <node concept="3VMn$a" id="59GJRmKEMKf" role="2JHqPs" />
+      <node concept="3GCHUU" id="59GJRmKEMKh" role="3GCHUb">
+        <ref role="122Z_O" to="uj4r:2kMEKexN5U" resolve="Internet" />
+      </node>
+      <node concept="2ly357" id="59GJRmKEMKi" role="2lDr27">
+        <property role="DVXpC" value="Public" />
+        <property role="TrG5h" value="TZ.2" />
+        <node concept="3VMn$a" id="59GJRmKEMKj" role="2JHqPs" />
+        <node concept="3GCHUU" id="59GJRmKEMKl" role="3GCHUb">
+          <ref role="122Z_O" to="uj4r:2kMEKexN5Y" resolve="Public" />
+        </node>
+        <node concept="2ly357" id="59GJRmKEMKm" role="2lDr27">
+          <property role="DVXpC" value="Public Cloud" />
+          <property role="TrG5h" value="TZ.3" />
+          <node concept="3VMn$a" id="59GJRmKEMKn" role="2JHqPs" />
+          <node concept="3GCHUU" id="59GJRmKEMKp" role="3GCHUb">
+            <ref role="122Z_O" to="uj4r:2kMEKexN64" resolve="Public Cloud" />
+          </node>
+          <node concept="2ly357" id="59GJRmKEMKq" role="2lDr27">
+            <property role="DVXpC" value="Trusted Partner" />
+            <property role="TrG5h" value="TZ.4" />
+            <node concept="3VMn$a" id="59GJRmKEMKr" role="2JHqPs" />
+            <node concept="3GCHUU" id="59GJRmKEMKt" role="3GCHUb">
+              <ref role="122Z_O" to="uj4r:2kMEKexN6c" resolve="Trusted Partner" />
+            </node>
+            <node concept="2ly357" id="59GJRmKEMKu" role="2lDr27">
+              <property role="DVXpC" value="Private Secured" />
+              <property role="TrG5h" value="TZ.5" />
+              <node concept="3VMn$a" id="59GJRmKEMKv" role="2JHqPs" />
+              <node concept="3GCHUU" id="59GJRmKEMKx" role="3GCHUb">
+                <ref role="122Z_O" to="uj4r:2kMEKexN6m" resolve="Private Secured" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -3243,7 +3243,7 @@
         <node concept="3VMn$a" id="5F0rLLZnk48" role="3GS99T" />
       </node>
       <node concept="3GSqTS" id="1PEmpgFma1R" role="2H0S5D">
-        <property role="TrG5h" value="18" />
+        <property role="TrG5h" value="18 Devices connected to external interfaces e.g. USB ports, OBD port, used as a means to attack vehicle systems" />
       </node>
       <node concept="2H0S4X" id="1PEmpgFma1S" role="2H0S5D">
         <property role="TrG5h" value="External interfaces such as USB or other ports used as a point of attack, for example through code injection" />

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -53,6 +53,10 @@
       <concept id="1920997147009089272" name="com.moraad.suggestions.structure.AssRiskSuggestionFactory" flags="ng" index="CENT2" />
       <concept id="1920997147016143551" name="com.moraad.suggestions.structure.AssRiskAssistantNewRiskSuggestion" flags="ng" index="CLQ85" />
       <concept id="8675225129845988701" name="com.moraad.suggestions.structure.AssDsThreatenedByTsSuggestionFactory" flags="ng" index="2FpSCn" />
+      <concept id="4155569431961189920" name="com.moraad.suggestions.structure.InteractionAssistantSelector" flags="ng" index="2IbN91" />
+      <concept id="4155569431961199169" name="com.moraad.suggestions.structure.AssInteractionSuggestionFactory" flags="ng" index="2IbQSw">
+        <reference id="4155569431963318236" name="context" index="2I3FIX" />
+      </concept>
       <concept id="1069594670716434985" name="com.moraad.suggestions.structure.AssConceptUpdateSuggestionFactory" flags="ng" index="2JoWM6" />
       <concept id="1069594670716328269" name="com.moraad.suggestions.structure.ConceptUpdateAssistantSelector" flags="ng" index="2JpmZy" />
       <concept id="1715757343547858166" name="com.moraad.suggestions.structure.ClaimCreationAssistantSelector" flags="ng" index="2LfSj0" />
@@ -3981,6 +3985,451 @@
                 <ref role="122Z_O" to="uj4r:2kMEKexN6m" resolve="Private Secured" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2Q15JU" id="7tyS2pKL1to">
+    <property role="3GE5qa" value="Security Analysis.Assistants" />
+    <node concept="2IbN91" id="7tyS2pKL1tn" role="kmFqQ" />
+    <node concept="2IbQSw" id="7tyS2pKL1ts" role="2Q$E0J">
+      <ref role="2I3FIX" node="3who49D6lt2" resolve="DF.3" />
+      <node concept="3aHhih" id="7tyS2pKL1uO" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1uR" role="3aHmvd">
+          <ref role="2ClQv0" node="3who49D6lt2" resolve="DF.3" />
+          <node concept="k5JqA" id="7tyS2pKL1uW" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQli" resolve="BK.1" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uZ" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uU" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpf" resolve="BK.3" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uV" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1uX" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQrH" resolve="BK.5b" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+            <node concept="3$cmbp" id="7tyS2pKL1uY" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeE" resolve="TS.8" />
+            </node>
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1uS" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+            <node concept="3$cmbp" id="7tyS2pKL1uT" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeN" resolve="TS.9" />
+            </node>
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1v0" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQto" resolve="BK.6a" />
+            <ref role="2Dj$GC" node="3who49D6lt2" resolve="DF.3" />
+            <node concept="3$cmbp" id="7tyS2pKL1v1" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLex" resolve="TS.7" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1uP" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1vd" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u19" resolve="Server" />
+          <node concept="k5JqA" id="7tyS2pKL1vh" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vf" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vg" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1ve" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1uQ" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1vn" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u3k" resolve="ConECU" />
+          <node concept="k5JqA" id="7tyS2pKL1vs" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1vo" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:2Wj3TpYBON8" resolve="BK.4b" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1vp" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeW" resolve="TS.10" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vr" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vq" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1tq" role="2Q$E0J">
+      <ref role="2I3FIX" node="3who49D6ltb" resolve="DF.4" />
+      <node concept="3aHhih" id="7tyS2pKL1vz" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1vA" role="3aHmvd">
+          <ref role="2ClQv0" node="3who49D6ltb" resolve="DF.4" />
+          <node concept="k5JqA" id="7tyS2pKL1vF" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQli" resolve="BK.1" />
+            <ref role="2Dj$GC" node="3who49D6ltb" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vG" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="3who49D6ltb" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vC" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpf" resolve="BK.3" />
+            <ref role="2Dj$GC" node="3who49D6ltb" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vD" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="3who49D6ltb" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vE" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="3who49D6ltb" resolve="DF.4" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vB" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="3who49D6ltb" resolve="DF.4" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1v$" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1vO" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u3k" resolve="ConECU" />
+          <node concept="k5JqA" id="7tyS2pKL1vT" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1vP" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:2Wj3TpYBON8" resolve="BK.4b" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1vQ" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeW" resolve="TS.10" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vS" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1vR" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1v_" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1w0" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u1H" resolve="HU" />
+          <node concept="k5JqA" id="7tyS2pKL1w4" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1w2" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1w3" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1w1" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1tp" role="2Q$E0J">
+      <ref role="2I3FIX" node="3who49CIQPO" resolve="DF.1" />
+      <node concept="3aHhih" id="7tyS2pKL1tu" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1tx" role="3aHmvd">
+          <ref role="2ClQv0" node="3who49CIQPO" resolve="DF.1" />
+          <node concept="k5JqA" id="7tyS2pKL1tA" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQli" resolve="BK.1" />
+            <ref role="2Dj$GC" node="3who49CIQPO" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tB" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="3who49CIQPO" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tz" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpf" resolve="BK.3" />
+            <ref role="2Dj$GC" node="3who49CIQPO" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1t$" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="3who49CIQPO" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1t_" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="3who49CIQPO" resolve="DF.1" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1ty" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="3who49CIQPO" resolve="DF.1" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1tv" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1tJ" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u1H" resolve="HU" />
+          <node concept="k5JqA" id="7tyS2pKL1tN" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tL" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tM" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tK" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u1H" resolve="HU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1tw" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1tT" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u3k" resolve="ConECU" />
+          <node concept="k5JqA" id="7tyS2pKL1tY" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1tU" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:2Wj3TpYBON8" resolve="BK.4b" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1tV" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeW" resolve="TS.10" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tX" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1tW" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1tr" role="2Q$E0J">
+      <ref role="2I3FIX" node="3who49D6lsT" resolve="DF.2" />
+      <node concept="3aHhih" id="7tyS2pKL1u5" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1u8" role="3aHmvd">
+          <ref role="2ClQv0" node="3who49D6lsT" resolve="DF.2" />
+          <node concept="k5JqA" id="7tyS2pKL1ud" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQli" resolve="BK.1" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1ug" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1ub" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpf" resolve="BK.3" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uc" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1ue" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQrH" resolve="BK.5b" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+            <node concept="3$cmbp" id="7tyS2pKL1uf" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeE" resolve="TS.8" />
+            </node>
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1u9" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+            <node concept="3$cmbp" id="7tyS2pKL1ua" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeN" resolve="TS.9" />
+            </node>
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1uh" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQto" resolve="BK.6a" />
+            <ref role="2Dj$GC" node="3who49D6lsT" resolve="DF.2" />
+            <node concept="3$cmbp" id="7tyS2pKL1ui" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLex" resolve="TS.7" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1u6" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1uu" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u3k" resolve="ConECU" />
+          <node concept="k5JqA" id="7tyS2pKL1uz" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1uv" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:2Wj3TpYBON8" resolve="BK.4b" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1uw" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeW" resolve="TS.10" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uy" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1ux" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1u7" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1uE" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u19" resolve="Server" />
+          <node concept="k5JqA" id="7tyS2pKL1uI" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uG" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uH" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1uF" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u19" resolve="Server" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2IbQSw" id="7tyS2pKL1tt" role="2Q$E0J">
+      <ref role="2I3FIX" node="3who49D6ltk" resolve="DF.5" />
+      <node concept="3aHhih" id="7tyS2pKL1wa" role="3N3N22">
+        <property role="3aHm6j" value="Data Flow" />
+        <property role="133MFP" value="dataflow" />
+        <node concept="2Q16Lc" id="7tyS2pKL1wd" role="3aHmvd">
+          <ref role="2ClQv0" node="3who49D6ltk" resolve="DF.5" />
+          <node concept="k5JqA" id="7tyS2pKL1wi" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQli" resolve="BK.1" />
+            <ref role="2Dj$GC" node="3who49D6ltk" resolve="DF.5" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wj" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="3who49D6ltk" resolve="DF.5" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wf" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpf" resolve="BK.3" />
+            <ref role="2Dj$GC" node="3who49D6ltk" resolve="DF.5" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wg" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="3who49D6ltk" resolve="DF.5" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wh" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="3who49D6ltk" resolve="DF.5" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1we" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="3who49D6ltk" resolve="DF.5" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1wb" role="3N3N22">
+        <property role="3aHm6j" value="Component (Source)" />
+        <property role="133MFP" value="source" />
+        <node concept="2Q16Lc" id="7tyS2pKL1wr" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u3k" resolve="ConECU" />
+          <node concept="k5JqA" id="7tyS2pKL1ww" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5Jqw" id="7tyS2pKL1ws" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:2Wj3TpYBON8" resolve="BK.4b" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+            <node concept="3$cmbp" id="7tyS2pKL1wt" role="k5Jqx">
+              <ref role="122Z_O" node="60wEthBTLeW" resolve="TS.10" />
+            </node>
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wv" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wu" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u3k" resolve="ConECU" />
+          </node>
+        </node>
+      </node>
+      <node concept="3aHhih" id="7tyS2pKL1wc" role="3N3N22">
+        <property role="3aHm6j" value="Component (Target)" />
+        <property role="133MFP" value="target" />
+        <node concept="2Q16Lc" id="7tyS2pKL1wB" role="3aHmvd">
+          <ref role="2ClQv0" node="1E_VH$V8u4q" resolve="Steering" />
+          <node concept="k5JqA" id="7tyS2pKL1wF" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQmG" resolve="BK.2" />
+            <ref role="2Dj$GC" node="1E_VH$V8u4q" resolve="Steering" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wD" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQpp" resolve="BK.4" />
+            <ref role="2Dj$GC" node="1E_VH$V8u4q" resolve="Steering" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wE" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQqK" resolve="BK.5" />
+            <ref role="2Dj$GC" node="1E_VH$V8u4q" resolve="Steering" />
+          </node>
+          <node concept="k5JqA" id="7tyS2pKL1wC" role="2QGid4">
+            <ref role="2ClRH1" to="28fr:4CQftq3lQsu" resolve="BK.6" />
+            <ref role="2Dj$GC" node="1E_VH$V8u4q" resolve="Steering" />
           </node>
         </node>
       </node>

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -266,7 +266,7 @@
       </concept>
       <concept id="6495719316977867921" name="com.moraad.core.structure.ConceptElement" flags="ng" index="3bfFbs">
         <child id="6495719316977867929" name="requirements" index="3bfFbk" />
-        <child id="6495719316977867928" name="risk" index="3bfFbl" />
+        <child id="6495719316977867928" name="risks" index="3bfFbl" />
       </concept>
       <concept id="709149415121875681" name="com.moraad.core.structure.DamageCriteriaForClassAssignments" flags="ng" index="3cP9l3">
         <child id="709149415121878132" name="damageCriteriaAssignments" index="3cP9Jm" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -63,7 +63,15 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
+    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
@@ -72,6 +80,7 @@
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="92" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate2/StandardComposition2/models/MethodConfiguration.mps
+++ b/RemoteUpdate2/StandardComposition2/models/MethodConfiguration.mps
@@ -10,6 +10,9 @@
   </imports>
   <registry>
     <language id="028969a3-7835-44e7-99c9-9cc9e12c2778" name="de.itemis.ysec.methodConfiguration">
+      <concept id="8140327204155191530" name="de.itemis.ysec.methodConfiguration.structure.TrustLevelsDefinition" flags="ng" index="fTz2s">
+        <child id="8140327204155191533" name="levels" index="fTz2r" />
+      </concept>
       <concept id="4497791247486336887" name="de.itemis.ysec.methodConfiguration.structure.DamageClass" flags="ng" index="i8Y8S" />
       <concept id="7480212422238926806" name="de.itemis.ysec.methodConfiguration.structure.ImpactScale" flags="ng" index="2nNfD6">
         <property id="7480212422238960135" name="value" index="2nMRun" />
@@ -36,11 +39,24 @@
         <property id="8045787582102992758" name="value" index="uPLpr" />
       </concept>
       <concept id="5265403561757222969" name="de.itemis.ysec.methodConfiguration.structure.Stakeholder" flags="ng" index="CzX2t" />
+      <concept id="848894267652668100" name="de.itemis.ysec.methodConfiguration.structure.TrustLevel" flags="ng" index="2KyDCi">
+        <property id="7152850790341018718" name="value" index="qSweV" />
+      </concept>
       <concept id="227120341090634910" name="de.itemis.ysec.methodConfiguration.structure.AFLsDefinition" flags="ng" index="KRYwx">
         <child id="227120341090909991" name="values" index="KQXIo" />
       </concept>
       <concept id="227120341090635007" name="de.itemis.ysec.methodConfiguration.structure.AttackFeasibilityLevel" flags="ng" index="KRYx0">
         <property id="227120341090910048" name="minimalValue" index="KQXJv" />
+      </concept>
+      <concept id="848894267651765571" name="de.itemis.ysec.methodConfiguration.structure.TrustModel" flags="ng" index="2KY5ml">
+        <child id="8140327204155204736" name="trustLevelsDefinition" index="fTIjQ" />
+        <child id="4520112907071583232" name="trustBoundaryCategoriesDefinition" index="2O4_UX" />
+      </concept>
+      <concept id="4520112907071582378" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategoriesDefinition" flags="ng" index="2O4_Cn">
+        <child id="4520112907071582379" name="categories" index="2O4_Cm" />
+      </concept>
+      <concept id="4520112907071235583" name="de.itemis.ysec.methodConfiguration.structure.TrustBoundaryCategory" flags="ng" index="2O6gX2">
+        <property id="4520112907071235800" name="value" index="2O6gL_" />
       </concept>
       <concept id="1756525789544303273" name="de.itemis.ysec.methodConfiguration.structure.DamagePotentialsDefinition" flags="ng" index="OYqhf">
         <child id="1756525789544303274" name="values" index="OYqhc" />
@@ -4046,6 +4062,176 @@
     <node concept="3XNixs" id="1xzt3hRBvP3" role="3XNixv">
       <property role="3XNixp" value="Go.{n}" />
       <ref role="3XNEje" to="gi29:7PEeMXPNYKi" resolve="NamePattern_SecurityGoal" />
+    </node>
+  </node>
+  <node concept="2KY5ml" id="2kMEKexN5T">
+    <property role="TrG5h" value="Trust Model" />
+    <node concept="fTz2s" id="73Sg7pZ8d6f" role="fTIjQ">
+      <node concept="2KyDCi" id="2kMEKexN5U" role="fTz2r">
+        <property role="TrG5h" value="Internet" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5V" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeo" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNep" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeq" role="3VMn$3">
+              <property role="3VMn$Y" value="Internet" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNer" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNes" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNee" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN5Y" role="fTz2r">
+        <property role="TrG5h" value="Public" />
+        <property role="qSweV" value="1" />
+        <node concept="3VMn$a" id="2kMEKexN5Z" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNey" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNez" role="3VMn$3">
+              <property role="3VMn$Y" value="Untrusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe$" role="3VMn$3">
+              <property role="3VMn$Y" value="public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNe_" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNeg" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN64" role="fTz2r">
+        <property role="TrG5h" value="Public Cloud" />
+        <property role="qSweV" value="60" />
+        <node concept="3VMn$a" id="2kMEKexN65" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeE" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeF" role="3VMn$3">
+              <property role="3VMn$Y" value="Public" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeG" role="3VMn$3">
+              <property role="3VMn$Y" value="cloud" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeH" role="3VMn$3">
+              <property role="3VMn$Y" value="service" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNei" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6c" role="fTz2r">
+        <property role="TrG5h" value="Trusted Partner" />
+        <property role="qSweV" value="80" />
+        <node concept="3VMn$a" id="2kMEKexN6d" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeM" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeN" role="3VMn$3">
+              <property role="3VMn$Y" value="Vetted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeO" role="3VMn$3">
+              <property role="3VMn$Y" value="and" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeP" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeQ" role="3VMn$3">
+              <property role="3VMn$Y" value="partner" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNek" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2KyDCi" id="2kMEKexN6m" role="fTz2r">
+        <property role="TrG5h" value="Private Secured" />
+        <property role="qSweV" value="100" />
+        <node concept="3VMn$a" id="2kMEKexN6n" role="2JHqPs">
+          <node concept="3VMn$0" id="2kMEKexNeW" role="3VMn$6">
+            <node concept="3VMn$7" id="2kMEKexNeX" role="3VMn$3">
+              <property role="3VMn$Y" value="A" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeY" role="3VMn$3">
+              <property role="3VMn$Y" value="secured" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNeZ" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf0" role="3VMn$3">
+              <property role="3VMn$Y" value="within" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf1" role="3VMn$3">
+              <property role="3VMn$Y" value="a" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf2" role="3VMn$3">
+              <property role="3VMn$Y" value="trusted" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf3" role="3VMn$3">
+              <property role="3VMn$Y" value="private" />
+            </node>
+            <node concept="3VMn$7" id="2kMEKexNf4" role="3VMn$3">
+              <property role="3VMn$Y" value="zone" />
+            </node>
+          </node>
+        </node>
+        <node concept="1iSF2X" id="2kMEKexNem" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+    </node>
+    <node concept="2O4_Cn" id="3UUEFQaLz58" role="2O4_UX">
+      <node concept="2O6gX2" id="3UUEFQaLz5a" role="2O4_Cm">
+        <property role="2O6gL_" value="0" />
+        <node concept="3VMn$a" id="3UUEFQaLz5b" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5e" role="E7tE9">
+          <property role="1iTho6" value="C6EFCE" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5g" role="2O4_Cm">
+        <property role="2O6gL_" value="20" />
+        <node concept="3VMn$a" id="3UUEFQaLz5h" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5s" role="E7tE9">
+          <property role="1iTho6" value="C4D79B" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5u" role="2O4_Cm">
+        <property role="2O6gL_" value="40" />
+        <node concept="3VMn$a" id="3UUEFQaLz5v" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5C" role="E7tE9">
+          <property role="1iTho6" value="FFFF99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5E" role="2O4_Cm">
+        <property role="2O6gL_" value="60" />
+        <node concept="3VMn$a" id="3UUEFQaLz5F" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz5R" role="E7tE9">
+          <property role="1iTho6" value="FFEB9C" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz5T" role="2O4_Cm">
+        <property role="2O6gL_" value="80" />
+        <node concept="3VMn$a" id="3UUEFQaLz5U" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz69" role="E7tE9">
+          <property role="1iTho6" value="FFCC99" />
+        </node>
+      </node>
+      <node concept="2O6gX2" id="3UUEFQaLz6b" role="2O4_Cm">
+        <property role="2O6gL_" value="100" />
+        <node concept="3VMn$a" id="3UUEFQaLz6c" role="2JHqPs" />
+        <node concept="1iSF2X" id="3UUEFQaLz6u" role="E7tE9">
+          <property role="1iTho6" value="FFAAAA" />
+        </node>
+      </node>
     </node>
   </node>
 </model>


### PR DESCRIPTION
this PR migrates the examples to enable report template serialization in the 24.3 patch release and forward