### PR TITLE
Prepare examples for RCP release 25.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+trace.info text merge=mps
+generated text merge=mps
+dependencies text merge=mps
+*.mpl text merge=mps
+*.msd text merge=mps
+*.devkit text merge=mps
+*.mpr text merge=mps
+*.mpsr text merge=mps
+*.model text merge=mps
+*.mps text merge=mps

--- a/CvssAv/.mps/migration.xml
+++ b/CvssAv/.mps/migration.xml
@@ -5,6 +5,12 @@
     <entry key="com.moraad.migrations.AddSequencesChunkMigration" value="executed" />
     <entry key="com.moraad.reports.ExtractReportChunkMigration" value="executed" />
     <entry key="com.moraad.suggestions.AddSuggestionChunkMigration" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v182.ReapplyPatternMigration" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="project.migrated.version" value="213" />
   </component>
 </project>

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -17,7 +17,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -48,7 +48,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -56,7 +56,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -80,7 +80,6 @@
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="d02fa6fa-263d-40d9-92d8-b0207ccaf7e0(de.itemis.ysec.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -26,11 +26,11 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -17,7 +17,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -40,13 +40,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -71,7 +71,6 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -64,7 +64,7 @@
   <dependencyVersions>
     <module reference="1f27859a-c6f3-4ef1-b3b2-a3b47ab45240(CvssAvAnalysis)" version="0" />
     <module reference="440b241b-03fb-49dd-83b9-a5c49e6386e5(CvssAvComposition)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="d02fa6fa-263d-40d9-92d8-b0207ccaf7e0(de.itemis.ysec.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -72,7 +72,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -62,23 +62,13 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="1f27859a-c6f3-4ef1-b3b2-a3b47ab45240(CvssAvAnalysis)" version="0" />
     <module reference="440b241b-03fb-49dd-83b9-a5c49e6386e5(CvssAvComposition)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="d02fa6fa-263d-40d9-92d8-b0207ccaf7e0(de.itemis.ysec.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
+++ b/CvssAv/CvssAvAnalysis/models/CvssAvAnalysis.mps
@@ -1124,6 +1124,25 @@
         <property role="zGsxJ" value="20.0;20.0;199.5;55.0" />
       </node>
     </node>
+    <node concept="zGsxE" id="M86EbPxeR4" role="zGsxT">
+      <property role="1ueiNO" value="root.5946338502802586889_CT_Channels" />
+      <node concept="zGsxD" id="M86EbPxeR5" role="zGsxH">
+        <property role="2MHvPS" value="1369744772054848240_CT_Channels" />
+        <property role="zGsxJ" value="20.0;98.0;240.6666666666667;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeR6" role="zGsxH">
+        <property role="2MHvPS" value="root.5946338502802586889_CT_Channels" />
+        <property role="zGsxJ" value="0.0;0.0;0.0;0.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeR7" role="zGsxH">
+        <property role="2MHvPS" value="1369744772054109130_CT_Channels" />
+        <property role="zGsxJ" value="20.0;20.0;210.6666666666667;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeR8" role="zGsxH">
+        <property role="2MHvPS" value="1369744772054848234_CT_Channels" />
+        <property role="zGsxJ" value="20.0;176.0;253.33333333333337;57.99999999999999" />
+      </node>
+    </node>
   </node>
   <node concept="2zckJ6" id="1PEmpgFm7ws">
     <property role="3GE5qa" value="Item Definition" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -69,7 +69,6 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -39,13 +39,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -16,7 +16,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -62,7 +62,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="440b241b-03fb-49dd-83b9-a5c49e6386e5(CvssAvComposition)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="d02fa6fa-263d-40d9-92d8-b0207ccaf7e0(de.itemis.ysec.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -16,7 +16,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -47,7 +47,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -55,7 +55,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -61,22 +61,12 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="440b241b-03fb-49dd-83b9-a5c49e6386e5(CvssAvComposition)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="d02fa6fa-263d-40d9-92d8-b0207ccaf7e0(de.itemis.ysec.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -78,7 +78,6 @@
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="d02fa6fa-263d-40d9-92d8-b0207ccaf7e0(de.itemis.ysec.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -25,11 +25,11 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -70,7 +70,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/ISO21434/.mps/migration.xml
+++ b/ISO21434/.mps/migration.xml
@@ -6,6 +6,11 @@
     <entry key="com.moraad.reports.ExtractReportChunkMigration" value="executed" />
     <entry key="com.moraad.suggestions.AddSuggestionChunkMigration" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v182.ReapplyPatternMigration" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="project.migrated.version" value="213" />
   </component>
 </project>

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -13,7 +13,6 @@
   <sourcePath />
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -22,11 +22,11 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -67,7 +67,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -66,7 +66,6 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -36,13 +36,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -59,7 +59,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="ea36efc9-242c-402d-9cd6-9b37c96aac34(ISOComposition)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -13,7 +13,7 @@
   <sourcePath />
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -44,7 +44,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -52,7 +52,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -74,7 +74,6 @@
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -58,21 +58,11 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="ea36efc9-242c-402d-9cd6-9b37c96aac34(ISOComposition)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -70,7 +70,6 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -78,7 +78,6 @@
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -39,13 +39,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -16,7 +16,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -16,7 +16,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -47,7 +47,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -55,7 +55,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -71,7 +71,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -25,11 +25,11 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -63,7 +63,7 @@
   <dependencyVersions>
     <module reference="ea36efc9-242c-402d-9cd6-9b37c96aac34(ISOComposition)" version="0" />
     <module reference="8cdc011b-33c1-488b-ab6f-ecd326955614(ISOExample)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -61,22 +61,12 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="ea36efc9-242c-402d-9cd6-9b37c96aac34(ISOComposition)" version="0" />
     <module reference="8cdc011b-33c1-488b-ab6f-ecd326955614(ISOExample)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -1841,6 +1841,145 @@
         <property role="zGsxJ" value="0.0;0.0;0.0;0.0" />
       </node>
     </node>
+    <node concept="zGsxE" id="M86EbPxeza" role="zGsxT">
+      <property role="1ueiNO" value="root.3385079518864193965_CT_Channels" />
+      <node concept="zGsxD" id="M86EbPxezb" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901035_CT_Channels" />
+        <property role="zGsxJ" value="327.33331298828125;99.66666666666666;115.33333333333331;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezc" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901511_CT_Channels-&gt;1421532820436901035_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;22.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezd" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901511_CT_Channels" />
+        <property role="zGsxJ" value="232.0;112.33333333333333;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeze" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901083_CT_Channels" />
+        <property role="zGsxJ" value="32.0;177.66666666666666;128.66666666666663;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezf" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436900947_CT_Channels" />
+        <property role="zGsxJ" value="669.9999389648438;171.88888888888886;106.66666666666664;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezg" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901058_CT_Channels_CT_Channels_segPort_1421532820436901010_CT_Channels" />
+        <property role="zGsxJ" value="-12.0;61.999999999999986;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezh" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901139_CT_Channels" />
+        <property role="zGsxJ" value="574.6666259765625;179.1111111111111;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezi" role="zGsxH">
+        <property role="2MHvPS" value="3385079518864195089_CT_Channels" />
+        <property role="zGsxJ" value="574.6666259765625;20.0;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezj" role="zGsxH">
+        <property role="2MHvPS" value="3385079518864194526_CT_Channels_extPort_CT_Channels" />
+        <property role="zGsxJ" value="871.333251953125;21.22222222222222;82.0;19.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezk" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436900966_CT_Channels" />
+        <property role="zGsxJ" value="669.9999389648438;51.888888888888886;181.3333282470703;99.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezl" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436900966_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;43.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezm" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901139_CT_Channels-&gt;1421532820436900947_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;22.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezn" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901058_CT_Channels" />
+        <property role="zGsxJ" value="72.0;50.66666666666666;119.99999999999999;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezo" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901083_CT_Channels_CT_Channels_segPort_1421532820436901010_CT_Channels" />
+        <property role="zGsxJ" value="-12.0;200.66666666666666;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezp" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels" />
+        <property role="zGsxJ" value="574.6666259765625;85.55555555555554;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezq" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901083_CT_Channels_CT_Channels_segPort_1421532820436901083_CT_Channels" />
+        <property role="zGsxJ" value="-12.0;22.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezr" role="zGsxH">
+        <property role="2MHvPS" value="root.3385079518864193965_CT_Channels" />
+        <property role="zGsxJ" value="0.0;0.0;0.0;0.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezs" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436900966_CT_Channels_6810048113914128758_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezt" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901511_CT_Channels-&gt;1421532820436901058_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;34.66666666666666;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezu" role="zGsxH">
+        <property role="2MHvPS" value="3385079518864195089_CT_Channels-&gt;1421532820436900966_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;15.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezv" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901010_CT_Channels" />
+        <property role="zGsxJ" value="72.0;116.44444444444443;462.6666564941406;255.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezw" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901139_CT_Channels-&gt;1421532820436900966_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;71.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxezx" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901058_CT_Channels_CT_Channels_segPort_1421532820436901058_CT_Channels" />
+        <property role="zGsxJ" value="-12.0;11.33333333333333;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeC8" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901058_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="20.0;96.44444444444443;20.0;184.4444444444444" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeCx" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901511_CT_Channels-&gt;1421532820436901035_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeCV" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901083_CT_Channels_CT_Channels_via_[HLsys: Headlamp System -&gt; PowSwitAct]" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeDm" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901139_CT_Channels-&gt;1421532820436900947_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeDM" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901139_CT_Channels-&gt;1421532820436900966_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="637.9999389648438;129.88888888888886;637.9999389648438;189.99999999999997" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeEf" role="zGsxH">
+        <property role="2MHvPS" value="3385079518864195089_CT_Channels-&gt;1421532820436900966_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="637.9999389648438;73.88888888888889;637.9999389648438;41.77777777777777" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeEH" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901058_CT_Channels_CT_Channels_via_[HLsys: Headlamp System -&gt; BodyECU]" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeFc" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436901083_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="20.0;323.1111111111111;20.0;392.1111111111111;554.6666259765625;392.1111111111111;554.6666259765625;107.33333333333331" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeFG" role="zGsxH">
+        <property role="2MHvPS" value="8169644986487976592_CT_Channels-&gt;1421532820436900966_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeGd" role="zGsxH">
+        <property role="2MHvPS" value="1421532820436901511_CT_Channels-&gt;1421532820436901058_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="40.0;91.33333333333331;40.0;128.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeGJ" role="zGsxH">
+        <property role="2MHvPS" value="3385079518864195089_CT_Channels-&gt;3385079518864194526_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+    </node>
   </node>
   <node concept="2zckJ6" id="5wtRytMI6hA">
     <property role="3GE5qa" value="Item Definition" />

--- a/RemoteUpdate1/.mps/migration.xml
+++ b/RemoteUpdate1/.mps/migration.xml
@@ -6,6 +6,11 @@
     <entry key="com.moraad.reports.ExtractReportChunkMigration" value="executed" />
     <entry key="com.moraad.suggestions.AddSuggestionChunkMigration" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v182.ReapplyPatternMigration" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="project.migrated.version" value="213" />
   </component>
 </project>

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -64,7 +64,7 @@
   <dependencyVersions>
     <module reference="e5c88256-a8e9-4a75-9ca4-4863fca0d461(ExampleAnalysis)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -16,7 +16,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -72,7 +72,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -71,7 +71,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -25,12 +25,12 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -62,22 +62,12 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="e5c88256-a8e9-4a75-9ca4-4863fca0d461(ExampleAnalysis)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -40,13 +40,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -79,7 +79,6 @@
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -16,7 +16,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -48,7 +48,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -56,7 +56,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -951,54 +951,6 @@
     </node>
     <node concept="zGsxE" id="6zI261cWs0w" role="zGsxT">
       <property role="1ueiNO" value="6855894676760348640" />
-      <node concept="zGsxD" id="7UMEm_O2HAQ" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358317" />
-        <property role="zGsxJ" value="20.0;90.66666666666667;110.0;76.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAR" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358285" />
-        <property role="zGsxJ" value="316.46484375;20.0;496.498046875;227.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAS" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358477" />
-        <property role="zGsxJ" value="363.498046875;152.0;59.0;55.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAT" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358408" />
-        <property role="zGsxJ" value="363.498046875;56.0;113.0;76.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAU" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358356" />
-        <property role="zGsxJ" value="157.46484375;70.66666666666667;110.0;76.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAV" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358317.9129545665012132899.out" />
-        <property role="zGsxJ" value="110.0;32.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAW" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358285.9129545665012132899.in" />
-        <property role="zGsxJ" value="-12.0;102.66666666666667;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAX" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358477.9129545665016944912.in" />
-        <property role="zGsxJ" value="-12.0;21.5;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAY" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358408.9129545665016944921.in" />
-        <property role="zGsxJ" value="-12.0;32.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HAZ" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358356.9129545665012132899.in" />
-        <property role="zGsxJ" value="-12.0;32.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HB0" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358356.9129545665016944921.out" />
-        <property role="zGsxJ" value="110.0;17.333333333333332;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="7UMEm_O2HB1" role="zGsxH">
-        <property role="2MHvPS" value="6855894676760358356.9129545665016944912.out" />
-        <property role="zGsxJ" value="110.0;46.666666666666664;12.0;12.0" />
-      </node>
     </node>
     <node concept="zGsxE" id="6zI261cWs1u" role="zGsxT">
       <property role="1ueiNO" value="6855894676760358285" />
@@ -1275,6 +1227,117 @@
       <node concept="zGsxD" id="5pKEgM6KpR$" role="zGsxH">
         <property role="2MHvPS" value="6855894676760358356.6855894676760358477#9129545665016944912" />
         <property role="zGsxJ" value="304.0;103.83333333333334;304.0;46.5" />
+      </node>
+    </node>
+    <node concept="zGsxE" id="M86EbPxeMg" role="zGsxT">
+      <property role="1ueiNO" value="root.6855894676760348640_CT_Channels" />
+      <node concept="zGsxD" id="M86EbPxeMh" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels" />
+        <property role="zGsxJ" value="634.0;122.99999999999999;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMi" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358317_CT_Channels_9129545665016944932_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMj" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673631_CT_Channels" />
+        <property role="zGsxJ" value="253.3333282470703;183.33333333333331;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMk" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358356_CT_Channels" />
+        <property role="zGsxJ" value="348.6666564941406;69.33333333333331;181.3333282470703;99.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMl" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358317_CT_Channels_9129545665016944933_CT_Channels" />
+        <property role="zGsxJ" value="20.0;99.99999999999999;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMm" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358356_CT_Channels_9129545665016944930_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMn" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358477_CT_Channels" />
+        <property role="zGsxJ" value="136.66666158040363;170.66666666666663;64.66666666666669;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMo" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels_segPort_6855894676760358356_CT_Channels" />
+        <property role="zGsxJ" value="181.3333282470703;43.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMp" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673631_CT_Channels-&gt;6855894676760358477_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="64.66666666666669;22.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMq" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358317_CT_Channels" />
+        <property role="zGsxJ" value="729.3333129882812;64.66666666666666;181.3333282470703;149.33333333333331" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMr" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673631_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;62.66666666666666;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMs" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673637_CT_Channels" />
+        <property role="zGsxJ" value="253.3333282470703;84.33333333333331;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMt" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673637_CT_Channels-&gt;6855894676760358408_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="181.3333282470703;43.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMu" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358285_CT_Channels" />
+        <property role="zGsxJ" value="20.0;20.0;562.0;248.66666666666663" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMv" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels-&gt;6855894676760358317_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;68.66666666666666;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMw" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358408_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;181.3333282470703;99.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMx" role="zGsxH">
+        <property role="2MHvPS" value="6855894676760358408_CT_Channels_9129545665016944931_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMy" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673637_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;25.33333333333333;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeMz" role="zGsxH">
+        <property role="2MHvPS" value="root.6855894676760348640_CT_Channels" />
+        <property role="zGsxJ" value="0.0;0.0;0.0;0.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeM$" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels_segPort_6855894676760358285_CT_Channels" />
+        <property role="zGsxJ" value="562.0;113.33333333333331;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeOl" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673637_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeOF" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673637_CT_Channels-&gt;6855894676760358408_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeP2" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels-&gt;6855894676760358317_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxePq" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673631_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="316.6666564941406;199.66666666666666;316.6666564941406;137.99999999999997" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxePN" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels_via_[VHC: Vehicle -&gt; GW]" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeQd" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673625_CT_Channels-&gt;6855894676760358356_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeQC" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788673631_CT_Channels-&gt;6855894676760358477_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
       </node>
     </node>
   </node>

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -13,7 +13,6 @@
   <sourcePath />
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -75,7 +75,6 @@
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -68,7 +68,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -13,7 +13,7 @@
   <sourcePath />
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -45,7 +45,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -53,7 +53,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -60,7 +60,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -67,7 +67,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -59,21 +59,11 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="fed5b234-fad3-4996-8ddc-1d3fd5d84092(StandardComposition)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -22,12 +22,12 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -37,13 +37,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/RemoteUpdate2/.mps/migration.xml
+++ b/RemoteUpdate2/.mps/migration.xml
@@ -6,6 +6,11 @@
     <entry key="com.moraad.reports.ExtractReportChunkMigration" value="executed" />
     <entry key="com.moraad.suggestions.AddSuggestionChunkMigration" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v182.ReapplyPatternMigration" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="project.migrated.version" value="213" />
   </component>
 </project>

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -16,7 +16,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -64,7 +64,7 @@
   <dependencyVersions>
     <module reference="9d40c97c-ad78-428c-bfe2-2c091d2c2af8(ExampleAnalysis)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -71,7 +71,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -25,12 +25,12 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -62,22 +62,12 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="9d40c97c-ad78-428c-bfe2-2c091d2c2af8(ExampleAnalysis)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -40,13 +40,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -72,7 +72,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -79,7 +79,6 @@
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -16,7 +16,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -48,7 +48,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -56,7 +56,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -1277,74 +1277,6 @@
     </node>
     <node concept="zGsxE" id="1jCjfTcpdfj" role="zGsxT">
       <property role="1ueiNO" value="1920203432910773854" />
-      <node concept="zGsxD" id="1jCjfTcpdfk" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774325" />
-        <property role="zGsxJ" value="0.0;0.0;154.0;122.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfl" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774554" />
-        <property role="zGsxJ" value="5.0;41.0;94.0;53.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfm" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774325.4040116179075422018.in" />
-        <property role="zGsxJ" value="-12.0;0.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfn" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774325.4040116179075422009.out" />
-        <property role="zGsxJ" value="154.0;0.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfo" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774345" />
-        <property role="zGsxJ" value="0.0;0.0;110.0;74.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfp" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774484" />
-        <property role="zGsxJ" value="5.0;41.0;120.0;74.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfq" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774381" />
-        <property role="zGsxJ" value="5.0;41.0;73.0;53.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfr" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774554.4040116179075422036.in" />
-        <property role="zGsxJ" value="-12.0;0.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfs" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774345.4040116179075422009.in" />
-        <property role="zGsxJ" value="-12.0;0.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdft" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774345.4040116179075422018.out" />
-        <property role="zGsxJ" value="110.0;0.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfu" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774484.4040116179075422018.in" />
-        <property role="zGsxJ" value="-12.0;14.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfv" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774484.4040116179075422027.out" />
-        <property role="zGsxJ" value="120.0;14.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfw" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774484.4040116179075422036.out" />
-        <property role="zGsxJ" value="120.0;28.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfx" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774484.4040116179069267316.in" />
-        <property role="zGsxJ" value="-12.0;28.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfy" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774484.4040116179075422009.out" />
-        <property role="zGsxJ" value="120.0;42.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdfz" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774381.4040116179069267316.out" />
-        <property role="zGsxJ" value="73.0;0.0;12.0;12.0" />
-      </node>
-      <node concept="zGsxD" id="1jCjfTcpdf$" role="zGsxH">
-        <property role="2MHvPS" value="1920203432910774381.4040116179075422027.in" />
-        <property role="zGsxJ" value="-12.0;0.0;12.0;12.0" />
-      </node>
     </node>
     <node concept="zGsxE" id="50CLgtloxcR" role="zGsxT">
       <property role="1ueiNO" value="1920203432910773854" />
@@ -1741,6 +1673,109 @@
       <node concept="zGsxD" id="5pKEgM6Kq0M" role="zGsxH">
         <property role="2MHvPS" value="1920203432910774484.1920203432910774381#4040116179075422027" />
         <property role="zGsxJ" value="261.0;50.91666666666667;261.0;48.41666666666667;125.0;48.41666666666667;125.0;37.41666666666667" />
+      </node>
+    </node>
+    <node concept="zGsxE" id="M86EbPxeHi" role="zGsxT">
+      <property role="1ueiNO" value="root.1920203432910773854_CT_Channels" />
+      <node concept="zGsxD" id="M86EbPxeHj" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686092_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;25.33333333333333;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHk" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774554_CT_Channels" />
+        <property role="zGsxJ" value="20.0;52.999999999999986;91.33333333333331;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHl" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686078_CT_Channels-&gt;1920203432910774381_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="-12.0;22.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHm" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels-&gt;1920203432910774345_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="181.3333282470703;43.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHn" role="zGsxH">
+        <property role="2MHvPS" value="root.1920203432910773854_CT_Channels" />
+        <property role="zGsxJ" value="0.0;0.0;0.0;0.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHo" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels_segPort_1920203432910774325_CT_Channels" />
+        <property role="zGsxJ" value="-12.0;124.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHp" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686092_CT_Channels" />
+        <property role="zGsxJ" value="163.33334350585938;65.66666666666666;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHq" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774325_CT_Channels" />
+        <property role="zGsxJ" value="348.6666564941406;20.0;682.6666259765625;170.66666666666663" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHr" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels" />
+        <property role="zGsxJ" value="253.3333282470703;134.66666666666666;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHs" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686078_CT_Channels" />
+        <property role="zGsxJ" value="492.0;84.33333333333331;43.33333333333334;32.66666666666666" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHt" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774345_CT_Channels" />
+        <property role="zGsxJ" value="20.0;101.0;181.3333282470703;99.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHu" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774345_CT_Channels_4040116179075422046_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHv" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774484_CT_Channels_4040116179075422045_CT_Channels" />
+        <property role="zGsxJ" value="20.0;50.66666666666666;141.33333333333331;29.333333333333332" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHw" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774484_CT_Channels" />
+        <property role="zGsxJ" value="258.6666717529297;50.66666666666666;181.3333282470703;99.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHx" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686078_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="181.3333282470703;43.99999999999999;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHy" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels_segPort_1920203432910774484_CT_Channels" />
+        <property role="zGsxJ" value="-12.0;62.66666666666666;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeHz" role="zGsxH">
+        <property role="2MHvPS" value="1920203432910774381_CT_Channels" />
+        <property role="zGsxJ" value="587.3333129882812;71.66666666666666;75.33333333333331;57.99999999999999" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeH$" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686092_CT_Channels-&gt;1920203432910774554_CT_Channels_CT_Channels_epPort" />
+        <property role="zGsxJ" value="91.33333333333331;22.999999999999996;12.0;12.0" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeJJ" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686078_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeK3" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels-&gt;1920203432910774345_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeKo" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686092_CT_Channels-&gt;1920203432910774554_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeKI" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeL5" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686078_CT_Channels-&gt;1920203432910774381_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeLt" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686092_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels" />
+        <property role="zGsxJ" value="" />
+      </node>
+      <node concept="zGsxD" id="M86EbPxeLQ" role="zGsxH">
+        <property role="2MHvPS" value="4326826167788686084_CT_Channels-&gt;1920203432910774484_CT_Channels_CT_Channels_via_[VEH: Vehicle -&gt; ConECU]" />
+        <property role="zGsxJ" value="226.6666717529297;131.0;226.6666717529297;119.33333333333331" />
       </node>
     </node>
   </node>

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -78,7 +78,6 @@
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
-    <module reference="9e4833f4-5a7f-4fbd-a204-b742d0550bb8(de.itemis.ysec.userScripts.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -16,7 +16,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -71,7 +71,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
     <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
-    <module reference="8f16104e-22e6-406d-8251-ef9688474557(com.mbeddr.mpsutil.refactoring.rt)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -62,21 +62,11 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
-    <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
-    <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -25,12 +25,12 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="93" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />
     <language slang="l:c68d0460-5886-45c2-81db-64ec5eed0b19:com.moraad.reports.html" version="0" />
-    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="0" />
+    <language slang="l:a97beefa-b088-4bdb-8ed8-6b4e554b6264:com.moraad.sequences" version="1" />
     <language slang="l:8aedd025-5f31-4a1e-81a1-4c5345407211:com.moraad.suggestions" version="4" />
     <language slang="l:3b2e8e7c-a0de-4faa-ad48-1ee43c2e27ac:com.moraad.userScripts" version="0" />
     <language slang="l:e8cdedba-17d0-43f7-902f-38efdcd30769:de.itemis.mps.commons" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -70,7 +70,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
-    <module reference="ab71436a-a7d1-4689-ac02-b5fde2ec681f(com.mbeddr.mpsutil.graphstream.runtime)" version="0" />
     <module reference="c0c29873-b2f7-413b-b508-0ba5b325a1d0(com.moraad.core.runtime)" version="0" />
     <module reference="b4294564-6583-4f72-81aa-5b6fc2f1be67(de.itemis.mps.commons.runtime)" version="0" />
     <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -40,13 +40,13 @@
     <language slang="l:b65d571f-daea-41e5-99be-6168217ee77f:de.itemis.mps.todos" version="0" />
     <language slang="l:d8c07454-d390-4e04-8826-d25e86f59134:de.itemis.mps.xdiagram" version="0" />
     <language slang="l:174fc1bc-8a89-4d07-8636-8bc5dc4757e4:de.itemis.vcs_text.tables" version="0" />
-    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.application.utils" version="0" />
     <language slang="l:77390b0e-ab69-4de7-a036-d557f81b479e:de.itemis.ysec.catalog.technologies" version="0" />
     <language slang="l:7234d3fa-3f51-44a6-b03f-4596bf1cc5e5:de.itemis.ysec.catalogs.core" version="0" />
     <language slang="l:24e88a55-f0b5-4dc5-9077-49730e920865:de.itemis.ysec.checklist" version="1" />
     <language slang="l:edd58c45-9999-4ad9-8f8a-e0d26da1cbc9:de.itemis.ysec.commons" version="0" />
     <language slang="l:028969a3-7835-44e7-99c9-9cc9e12c2778:de.itemis.ysec.methodConfiguration" version="7" />
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
+    <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -63,7 +63,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="79fb18c6-3846-4eb9-a413-143c6c735e81(StandardComposition2)" version="0" />
-    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.runtime)" version="0" />
+    <module reference="f38527c6-3966-46ff-88e4-7a52d4ab2235(de.itemis.ysec.checklist.templates)" version="0" />
     <module reference="653446a7-cd5f-437e-8771-dcfb81a48316(de.itemis.ysec.commons.lib)" version="0" />
     <module reference="55293ae5-03b4-4178-ac73-d41d647b48ac(de.itemis.ysec.terminology.lib)" version="0" />
     <module reference="5b8291da-a6cc-445d-aaaa-1313cd19263d(io.yakindu.ysec.lib)" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -16,7 +16,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:67506b1e-43ad-47fe-a8e6-bc7837e9e11f:com.mbeddr.mpsutil.editingGuide" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
@@ -48,7 +48,7 @@
     <language slang="l:2307a511-c189-4bbb-ae4d-e1f113c91dbe:de.itemis.ysec.methodConfiguration.baseLanguageExtensions" version="1" />
     <language slang="l:1ce18c1e-e691-4909-8d5e-b4ddc758064f:de.itemis.ysec.obfuscation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -56,7 +56,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />


### PR DESCRIPTION
this introduces a few changes and prepares the next release
- adapted new System Diagram defaults
- removal of Risk Model generation
- subsequently simplified project setup
- migrated platform